### PR TITLE
Add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ edition = "2021"
 enum_dispatch = "0.3.8"
 byteorder = "1.4.3"
 ordered-float = "3.4.0"
+serde = { version = "1.0", optional = true, features = ["derive"] }
+
+[features]
+serde = ["dep:serde", "ordered-float/serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ use types::Guid;
 
 /// Stores UE4 version in which the GVAS file was saved
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FEngineVersion {
     pub major: u16,
     pub minor: u16,
@@ -139,6 +140,7 @@ impl FEngineVersion {
 
 /// Stores CustomVersions serialized by UE4
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FCustomVersion {
     pub key: Guid,
     pub version: i32,
@@ -171,6 +173,7 @@ impl FCustomVersion {
 
 /// Stores information about GVAS file, engine version, etc.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GvasHeader {
     pub file_type_tag: i32,
     pub save_game_file_version: i32,
@@ -292,6 +295,7 @@ impl GvasHeader {
 
 /// Main UE4 save file struct
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GvasFile {
     pub header: GvasHeader,
     pub properties: HashMap<String, Property>,

--- a/src/properties/array_property.rs
+++ b/src/properties/array_property.rs
@@ -7,7 +7,7 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
     cursor_ext::CursorExt,
-    error::{Error, SerializeError},
+    error::{Error, SerializeError}, types::Guid,
 };
 
 use super::{struct_property::StructProperty, Property, PropertyTrait};
@@ -17,7 +17,7 @@ use super::{struct_property::StructProperty, Property, PropertyTrait};
 struct ArrayStructInfo {
     type_name: String,
     field_name: String,
-    guid: [u8; 16],
+    guid: Guid,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -38,7 +38,7 @@ impl ArrayProperty {
         let array_struct_info = field_name.map(|field_name| ArrayStructInfo {
             field_name,
             type_name: "".to_string(),
-            guid: [0u8; 16],
+            guid: Guid([0u8; 16]),
         });
 
         ArrayProperty {
@@ -91,7 +91,7 @@ impl ArrayProperty {
                 array_struct_info = Some(ArrayStructInfo {
                     type_name: struct_name,
                     field_name,
-                    guid: struct_guid,
+                    guid: Guid(struct_guid),
                 });
             }
             _ => {
@@ -148,7 +148,7 @@ impl PropertyTrait for ArrayProperty {
                 let begin_without_name = cursor.position();
                 cursor.write_u64::<LittleEndian>(0)?;
                 cursor.write_string(&array_struct_info.type_name)?;
-                let _ = cursor.write(&array_struct_info.guid)?;
+                let _ = cursor.write(&array_struct_info.guid.0)?;
                 let _ = cursor.write(&[0u8; 1])?;
 
                 for property in &self.properties {

--- a/src/properties/array_property.rs
+++ b/src/properties/array_property.rs
@@ -13,6 +13,7 @@ use crate::{
 use super::{struct_property::StructProperty, Property, PropertyTrait};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct ArrayStructInfo {
     type_name: String,
     field_name: String,
@@ -20,6 +21,7 @@ struct ArrayStructInfo {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ArrayProperty {
     pub property_type: String,
     pub properties: Vec<Property>,

--- a/src/properties/enum_property.rs
+++ b/src/properties/enum_property.rs
@@ -7,6 +7,7 @@ use crate::{cursor_ext::CursorExt, error::Error};
 use super::PropertyTrait;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnumProperty {
     enum_type: String,
     value: String,

--- a/src/properties/int_property.rs
+++ b/src/properties/int_property.rs
@@ -22,6 +22,7 @@ macro_rules! check_size {
 macro_rules! impl_int_property {
     ($name:ident, $ty:ty, $read_method:ident, $write_method:ident, $size:literal) => {
         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         pub struct $name {
             pub value: $ty,
         }
@@ -64,6 +65,7 @@ macro_rules! impl_int_property {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Int8Property {
     pub value: i8,
 }
@@ -97,6 +99,7 @@ impl PropertyTrait for Int8Property {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ByteProperty {
     pub name: Option<String>,
     pub value: u8,
@@ -137,6 +140,7 @@ impl PropertyTrait for ByteProperty {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BoolProperty {
     pub value: bool,
 }
@@ -172,6 +176,7 @@ impl PropertyTrait for BoolProperty {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FloatProperty {
     pub value: OrderedFloat<f32>,
 }
@@ -207,6 +212,7 @@ impl PropertyTrait for FloatProperty {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DoubleProperty {
     pub value: OrderedFloat<f64>,
 }

--- a/src/properties/map_property.rs
+++ b/src/properties/map_property.rs
@@ -11,6 +11,7 @@ use crate::{cursor_ext::CursorExt, error::Error, scoped_stack_entry::ScopedStack
 use super::{Property, PropertyTrait};
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MapProperty {
     pub key_type: String,
     pub value_type: String,

--- a/src/properties/map_property.rs
+++ b/src/properties/map_property.rs
@@ -16,7 +16,7 @@ pub struct MapProperty {
     pub key_type: String,
     pub value_type: String,
     pub allocation_flags: u32,
-    #[cfg_attr(feature = "serde", serde(with = "value_serde"))]
+    #[cfg_attr(feature = "serde", serde(with = "serde_value_impl"))]
     pub value: HashMap<Property, Property>,
 }
 
@@ -125,7 +125,7 @@ impl Hash for MapProperty {
 }
 
 #[cfg(feature = "serde")]
-mod value_serde {
+mod serde_value_impl {
     use std::collections::HashMap;
 
     use serde::de::Deserializer;
@@ -135,7 +135,7 @@ mod value_serde {
     use super::Property;
 
     #[derive(Serialize, Deserialize)]
-    struct KVPair<T> {
+    struct Entry<T> {
         key: T,
         value: T,
     }
@@ -144,7 +144,7 @@ mod value_serde {
     where
         S: Serializer,
     {
-        serializer.collect_seq(map.iter().map(|x| KVPair {
+        serializer.collect_seq(map.iter().map(|x| Entry {
             key: x.0,
             value: x.1,
         }))
@@ -154,7 +154,7 @@ mod value_serde {
     where
         D: Deserializer<'de>,
     {
-        Ok(Vec::<KVPair<Property>>::deserialize(deserializer)?
+        Ok(Vec::<Entry<Property>>::deserialize(deserializer)?
             .into_iter()
             .map(|x| (x.key, x.value))
             .collect())

--- a/src/properties/mod.rs
+++ b/src/properties/mod.rs
@@ -47,6 +47,7 @@ pub trait PropertyTrait: Debug + Clone + PartialEq + Eq + Hash {
 }
 
 #[enum_dispatch(PropertyTrait)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(tag = "type"))]
 pub enum Property {
     Int8Property,
     ByteProperty,

--- a/src/properties/set_property.rs
+++ b/src/properties/set_property.rs
@@ -10,6 +10,7 @@ use crate::{cursor_ext::CursorExt, error::Error};
 use super::{Property, PropertyTrait};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetProperty {
     pub property_type: String,
     pub allocation_flags: u32,

--- a/src/properties/str_property.rs
+++ b/src/properties/str_property.rs
@@ -7,6 +7,7 @@ use crate::{cursor_ext::CursorExt, error::Error};
 use super::PropertyTrait;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StrProperty {
     pub value: String,
 }

--- a/src/properties/struct_property.rs
+++ b/src/properties/struct_property.rs
@@ -472,16 +472,21 @@ impl serde::Serialize for StructProperty {
         S: serde::Serializer,
     {
         #[derive(serde::Serialize)]
-        struct StructPropertyWithResolvedValue<'a> {
-            #[serde(flatten)]
-            struct_property: &'a StructProperty,
+        struct StructProperty<'a> {
+            type_name: &'a String,
+            guid: &'a Guid,
+            properties: &'a HashMap<String, Property>,
+
             #[serde(skip_serializing_if = "Option::is_none")]
-            value: Option<Guid>
+            value: Option<Guid>,
         }
 
-        StructPropertyWithResolvedValue {
-            struct_property: self,
-            value: self.get_guid()
-        }.serialize(serializer)
+        StructProperty {
+            type_name: &self.type_name,
+            guid: &self.guid,
+            properties: &self.properties,
+            value: self.get_guid(),
+        }
+        .serialize(serializer)
     }
 }

--- a/src/properties/struct_property.rs
+++ b/src/properties/struct_property.rs
@@ -31,6 +31,7 @@ macro_rules! write_flat_property {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StructProperty {
     pub type_name: String,
     pub guid: Guid,

--- a/src/properties/unknown_property.rs
+++ b/src/properties/unknown_property.rs
@@ -8,6 +8,7 @@ use super::PropertyTrait;
 
 /// This struct is read when a property is unknown to the deserializer
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnknownProperty {
     property_name: String,
     raw: Vec<u8>,


### PR DESCRIPTION
This pull request adds serde support behind a `"serde"` feature.

This is allows you to convert the parsed gvas data to and from many common formats such as JSON. This can be useful to process the data in other programming languages or general purpose JSON processing tools (for example generate TypeScript types from JSON to help determine the structure of the data).

For the most part this involves just adding `#derive(Serialize, Deserialize)` to relevant structs, however, there are some places where custom logic was added:
* The Property enum is internally tagged, with the property type contained in the field "type", because this felt like the most compact and natural option.
* MapProperty values are serialized as a list of `{"key": ..., "value": ...}` structs. This was done because JSON only allows string keys in maps.
* If a StructProperty contains a GUID it is serialized with an additional field "value" containing the GUID value as a string in the standard format (matching the Debug trait logic). This was done to make working with GUID StructProperties more convenient and more consistent with how GUID-s are shown in other parts of the serialized output. The "properties" field is serialized for all StructProperties to allow for generic processing of all StructProperties regardless of if they contain a GUID or not.