### PR TITLE
Replace Cursor with Read|Write + Seek

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,8 @@ use std::{
     path::Path,
 };
 
-let mut file = File::open("save.sav").unwrap();
-let mut data = Vec::new();
-file.read_to_end(&mut data).unwrap();
-
-let mut cursor = Cursor::new(data);
-let gvas_file = GvasFile::read(&mut cursor);
+let mut file = File::open("save.sav")?;
+let gvas_file = GvasFile::read(&mut file);
 
 println!("{:#?}", gvas_file);
 ```

--- a/src/cursor_ext.rs
+++ b/src/cursor_ext.rs
@@ -1,27 +1,32 @@
-use std::io::Cursor;
+use std::io::{Read, Seek, Write};
 
 use unreal_helpers::{UnrealReadExt, UnrealWriteExt};
 
 use crate::error::{DeserializeError, Error};
 
-/// Extensions for `Cursor`
-pub trait CursorExt {
+/// Extensions for `Read`.
+pub trait ReadExt {
     /// Reads a GVAS string.
     fn read_string(&mut self) -> Result<String, Error>;
-    /// Writes a GVAS string.
-    fn write_string(&mut self, v: &str) -> Result<(), Error>;
 }
 
-impl CursorExt for Cursor<Vec<u8>> {
+/// Extensions for `Write`.
+pub trait WriteExt {
+    /// Writes a GVAS string.
+    fn write_string(&mut self, v: &str) -> Result<usize, Error>;
+}
+
+impl<R: Read + Seek> ReadExt for R {
     fn read_string(&mut self) -> Result<String, Error> {
         match self.read_fstring()? {
             Some(str) => Ok(str),
-            None => Err(DeserializeError::InvalidString(0, self.position()))?,
+            None => Err(DeserializeError::InvalidString(0, self.stream_position()?))?,
         }
     }
+}
 
-    fn write_string(&mut self, v: &str) -> Result<(), Error> {
-        self.write_fstring(Some(v))?;
-        Ok(())
+impl<W: Write> WriteExt for W {
+    fn write_string(&mut self, v: &str) -> Result<usize, Error> {
+        Ok(self.write_fstring(Some(v))?)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,11 +31,14 @@ pub enum DeserializeError {
 
 impl DeserializeError {
     /// A helper for creating `MissingArgument` errors
-    pub fn missing_argument(argument_name: &str, position: u64) -> Self {
+    pub fn missing_argument<S: io::Seek>(argument_name: &str, stream: &mut S) -> Self {
+        let position = stream.stream_position().unwrap_or_default();
         Self::MissingArgument(argument_name.to_string(), position)
     }
+
     /// A helper for creating `InvalidProperty` errors
-    pub fn invalid_property(reason: &str, position: u64) -> Self {
+    pub fn invalid_property<S: io::Seek>(reason: &str, stream: &mut S) -> Self {
+        let position = stream.stream_position().unwrap_or_default();
         Self::InvalidProperty(reason.to_string(), position)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub mod types;
 use std::{
     collections::HashMap,
     fmt::{Debug, Display},
-    io::{Cursor, Read, Write},
+    io::{Cursor, Read, Seek, Write},
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -148,7 +148,7 @@ impl FEngineVersion {
     }
 
     /// Write FEngineVersion to a binary file
-    pub(crate) fn write(&self, cursor: &mut Cursor<Vec<u8>>) -> Result<(), Error> {
+    pub(crate) fn write<W: Write>(&self, cursor: &mut W) -> Result<(), Error> {
         cursor.write_u16::<LittleEndian>(self.major)?;
         cursor.write_u16::<LittleEndian>(self.minor)?;
         cursor.write_u16::<LittleEndian>(self.patch)?;
@@ -187,7 +187,7 @@ impl FCustomVersion {
     }
 
     /// Write FCustomVersion to a binary file
-    pub(crate) fn write(&self, cursor: &mut Cursor<Vec<u8>>) -> Result<(), Error> {
+    pub(crate) fn write<W: Write>(&self, cursor: &mut W) -> Result<(), Error> {
         let _ = cursor.write(&self.key.0)?;
         cursor.write_i32::<LittleEndian>(self.version)?;
         Ok(())
@@ -317,7 +317,7 @@ impl GvasHeader {
     /// println!("{:#?}", writer.get_ref());
     /// # Ok::<(), Error>(())
     /// ```
-    pub fn write(&self, cursor: &mut Cursor<Vec<u8>>) -> Result<(), Error> {
+    pub fn write<W: Write>(&self, cursor: &mut W) -> Result<(), Error> {
         cursor.write_i32::<LittleEndian>(self.file_type_tag)?;
         cursor.write_i32::<LittleEndian>(self.save_game_file_version)?;
         cursor.write_i32::<LittleEndian>(self.package_file_ue4_version)?;
@@ -478,7 +478,7 @@ impl GvasFile {
     /// println!("{:#?}", writer.get_ref());
     /// # Ok::<(), Error>(())
     /// ```
-    pub fn write(&self, cursor: &mut Cursor<Vec<u8>>) -> Result<(), Error> {
+    pub fn write<W: Write + Seek>(&self, cursor: &mut W) -> Result<(), Error> {
         self.header.write(cursor)?;
 
         for (name, property) in &self.properties {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub mod types;
 use std::{
     collections::HashMap,
     fmt::{Debug, Display},
-    io::{Cursor, Read, Seek, Write},
+    io::{Read, Seek, Write},
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -132,7 +132,7 @@ impl FEngineVersion {
     }
 
     /// Read FEngineVersion from a binary file
-    pub(crate) fn read(cursor: &mut Cursor<Vec<u8>>) -> Result<Self, Error> {
+    pub(crate) fn read<R: Read + Seek>(cursor: &mut R) -> Result<Self, Error> {
         let major = cursor.read_u16::<LittleEndian>()?;
         let minor = cursor.read_u16::<LittleEndian>()?;
         let patch = cursor.read_u16::<LittleEndian>()?;
@@ -175,7 +175,7 @@ impl FCustomVersion {
     }
 
     /// Read FCustomVersion from a binary file
-    pub(crate) fn read(cursor: &mut Cursor<Vec<u8>>) -> Result<Self, Error> {
+    pub(crate) fn read<R: Read + Seek>(cursor: &mut R) -> Result<Self, Error> {
         let mut guid = [0u8; 16];
         cursor.read_exact(&mut guid)?;
         let version = cursor.read_i32::<LittleEndian>()?;
@@ -265,7 +265,7 @@ impl GvasHeader {
     /// println!("{:#?}", gvas_header);
     /// # Ok::<(), Error>(())
     /// ```
-    pub fn read(cursor: &mut Cursor<Vec<u8>>) -> Result<Self, Error> {
+    pub fn read<R: Read + Seek>(cursor: &mut R) -> Result<Self, Error> {
         let file_type_tag = cursor.read_i32::<LittleEndian>()?;
         if file_type_tag != FILE_TYPE_GVAS {
             Err(DeserializeError::InvalidFileType(file_type_tag))?
@@ -376,7 +376,7 @@ impl GvasFile {
     /// println!("{:#?}", gvas_file);
     /// # Ok::<(), Error>(())
     /// ```
-    pub fn read(cursor: &mut Cursor<Vec<u8>>) -> Result<Self, Error> {
+    pub fn read<R: Read + Seek>(cursor: &mut R) -> Result<Self, Error> {
         let hints = HashMap::new();
         Self::read_with_hints(cursor, &hints)
     }
@@ -418,8 +418,8 @@ impl GvasFile {
     /// println!("{:#?}", gvas_file);
     /// # Ok::<(), Error>(())
     /// ```
-    pub fn read_with_hints(
-        cursor: &mut Cursor<Vec<u8>>,
+    pub fn read_with_hints<R: Read + Seek>(
+        cursor: &mut R,
         hints: &HashMap<String, String>,
     ) -> Result<Self, Error> {
         let header = GvasHeader::read(cursor)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ use std::{
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use cursor_ext::CursorExt;
+use cursor_ext::{ReadExt, WriteExt};
 use error::Error;
 use indexmap::IndexMap;
 use properties::{Property, PropertyTrait};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,12 @@
 //! use gvas::{error::Error, GvasFile};
 //! use std::{
 //!     fs::File,
-//!     io::{Cursor, Read},
+//!     io::Read,
 //!     path::Path,
 //! };
 //!
 //! let mut file = File::open("save.sav")?;
-//! let mut data = Vec::new();
-//! file.read_to_end(&mut data)?;
-//!
-//! let mut cursor = Cursor::new(data);
-//! let gvas_file = GvasFile::read(&mut cursor);
+//! let gvas_file = GvasFile::read(&mut file);
 //!
 //! println!("{:#?}", gvas_file);
 //! # Ok::<(), Error>(())
@@ -50,19 +46,16 @@
 //! use std::{
 //!     collections::HashMap,
 //!     fs::File,
-//!     io::{Cursor, Read},
+//!     io::Read,
 //!     path::Path,
 //! };
 //!
 //! let mut file = File::open("save.sav")?;
-//! let mut data = Vec::new();
-//! file.read_to_end(&mut data)?;
 //!
 //! let mut hints = HashMap::new();
 //! hints.insert("UnLockedMissionParameters.MapProperty.Key.StructProperty".to_string(), "Guid".to_string());
 //!
-//! let mut cursor = Cursor::new(data);
-//! let gvas_file = GvasFile::read_with_hints(&mut cursor, &hints);
+//! let gvas_file = GvasFile::read_with_hints(&mut file, &hints);
 //!
 //! println!("{:#?}", gvas_file);
 //! # Ok::<(), Error>(())
@@ -251,16 +244,13 @@ impl GvasHeader {
     /// use gvas::{error::Error, GvasHeader};
     /// use std::{
     ///     fs::File,
-    ///     io::{Cursor, Read},
+    ///     io::Read,
     ///     path::Path,
     /// };
     ///
     /// let mut file = File::open("save.sav")?;
-    /// let mut data = Vec::new();
-    /// file.read_to_end(&mut data)?;
     ///
-    /// let mut cursor = Cursor::new(data);
-    /// let gvas_header = GvasHeader::read(&mut cursor)?;
+    /// let gvas_header = GvasHeader::read(&mut file)?;
     ///
     /// println!("{:#?}", gvas_header);
     /// # Ok::<(), Error>(())
@@ -306,11 +296,7 @@ impl GvasHeader {
     /// };
     ///
     /// let mut file = File::open("save.sav")?;
-    /// let mut data = Vec::new();
-    /// file.read_to_end(&mut data)?;
-    ///
-    /// let mut cursor = Cursor::new(data);
-    /// let gvas_header = GvasHeader::read(&mut cursor)?;
+    /// let gvas_header = GvasHeader::read(&mut file)?;
     ///
     /// let mut writer = Cursor::new(Vec::new());
     /// gvas_header.write(&mut writer)?;
@@ -362,16 +348,12 @@ impl GvasFile {
     /// use gvas::{error::Error, GvasFile};
     /// use std::{
     ///     fs::File,
-    ///     io::{Cursor, Read},
+    ///     io::Read,
     ///     path::Path,
     /// };
     ///
     /// let mut file = File::open("save.sav")?;
-    /// let mut data = Vec::new();
-    /// file.read_to_end(&mut data)?;
-    ///
-    /// let mut cursor = Cursor::new(data);
-    /// let gvas_file = GvasFile::read(&mut cursor);
+    /// let gvas_file = GvasFile::read(&mut file);
     ///
     /// println!("{:#?}", gvas_file);
     /// # Ok::<(), Error>(())
@@ -398,13 +380,11 @@ impl GvasFile {
     /// use std::{
     ///     collections::HashMap,
     ///     fs::File,
-    ///     io::{Cursor, Read},
+    ///     io::Read,
     ///     path::Path,
     /// };
     ///
     /// let mut file = File::open("save.sav")?;
-    /// let mut data = Vec::new();
-    /// file.read_to_end(&mut data)?;
     ///
     /// let mut hints = HashMap::new();
     /// hints.insert(
@@ -412,8 +392,7 @@ impl GvasFile {
     ///     "Guid".to_string(),
     /// );
     ///
-    /// let mut cursor = Cursor::new(data);
-    /// let gvas_file = GvasFile::read_with_hints(&mut cursor, &hints);
+    /// let gvas_file = GvasFile::read_with_hints(&mut file, &hints);
     ///
     /// println!("{:#?}", gvas_file);
     /// # Ok::<(), Error>(())
@@ -467,11 +446,7 @@ impl GvasFile {
     /// };
     ///
     /// let mut file = File::open("save.sav")?;
-    /// let mut data = Vec::new();
-    /// file.read_to_end(&mut data)?;
-    ///
-    /// let mut cursor = Cursor::new(data);
-    /// let gvas_file = GvasFile::read(&mut cursor)?;
+    /// let gvas_file = GvasFile::read(&mut file)?;
     ///
     /// let mut writer = Cursor::new(Vec::new());
     /// gvas_file.write(&mut writer)?;

--- a/src/properties/array_property.rs
+++ b/src/properties/array_property.rs
@@ -7,7 +7,7 @@ use std::{
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
-    cursor_ext::CursorExt,
+    cursor_ext::{ReadExt, WriteExt},
     error::{DeserializeError, Error, SerializeError},
     types::Guid,
 };

--- a/src/properties/enum_property.rs
+++ b/src/properties/enum_property.rs
@@ -69,12 +69,12 @@ impl EnumProperty {
 }
 
 impl PropertyTrait for EnumProperty {
-    fn write(&self, cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<(), Error> {
+    fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             cursor.write_string("EnumProperty")?;
         }
 
-        let begin = cursor.position();
+        let begin = cursor.stream_position()?;
         cursor.write_u64::<LittleEndian>(0)?;
 
         if self.compact_name {
@@ -84,9 +84,9 @@ impl PropertyTrait for EnumProperty {
             cursor.write_string(&self.enum_type)?;
             cursor.write_all(&[0u8; 1])?;
 
-            let value_begin = cursor.position();
+            let value_begin = cursor.stream_position()?;
             cursor.write_string(&self.value)?;
-            let value_end = cursor.position();
+            let value_end = cursor.stream_position()?;
 
             cursor.seek(SeekFrom::Start(begin))?;
             cursor.write_u64::<LittleEndian>(value_end - value_begin)?;

--- a/src/properties/enum_property.rs
+++ b/src/properties/enum_property.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Read, Seek, SeekFrom, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
@@ -28,7 +28,7 @@ impl EnumProperty {
         }
     }
 
-    pub(crate) fn read(cursor: &mut Cursor<Vec<u8>>) -> Result<Self, Error> {
+    pub(crate) fn read<R: Read + Seek>(cursor: &mut R) -> Result<Self, Error> {
         let _length = cursor.read_u64::<LittleEndian>()?;
 
         let read_enum_type = cursor.read_string()?;
@@ -44,7 +44,7 @@ impl EnumProperty {
             } else {
                 return Err(DeserializeError::InvalidEnumType(
                     read_enum_type,
-                    cursor.position(),
+                    cursor.stream_position()?,
                 ))?;
             }
             if let Some(e) = split.next() {
@@ -52,7 +52,7 @@ impl EnumProperty {
             } else {
                 return Err(DeserializeError::InvalidEnumType(
                     read_enum_type,
-                    cursor.position(),
+                    cursor.stream_position()?,
                 ))?;
             }
         } else {

--- a/src/properties/enum_property.rs
+++ b/src/properties/enum_property.rs
@@ -3,7 +3,7 @@ use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
-    cursor_ext::CursorExt,
+    cursor_ext::{ReadExt, WriteExt},
     error::{DeserializeError, Error},
 };
 

--- a/src/properties/int_property.rs
+++ b/src/properties/int_property.rs
@@ -5,6 +5,7 @@ use std::{
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use ordered_float::OrderedFloat;
+use unreal_helpers::{UnrealReadExt, UnrealWriteExt};
 
 use crate::{
     cursor_ext::{ReadExt, WriteExt},
@@ -203,11 +204,8 @@ impl BoolProperty {
             check_size!(cursor, 0);
             indicator = cursor.read_u8()?;
         }
-        let val = cursor.read_u8()?;
-        Ok(BoolProperty {
-            value: val > 0,
-            indicator,
-        })
+        let value = cursor.read_bool()?;
+        Ok(BoolProperty { value, indicator })
     }
 }
 
@@ -224,10 +222,7 @@ impl PropertyTrait for BoolProperty {
             cursor.write_i64::<LittleEndian>(0)?;
             cursor.write_u8(self.indicator)?;
         }
-        cursor.write_u8(match self.value {
-            true => 1,
-            false => 0,
-        })?;
+        cursor.write_bool(self.value)?;
         Ok(())
     }
 }

--- a/src/properties/int_property.rs
+++ b/src/properties/int_property.rs
@@ -7,7 +7,7 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use ordered_float::OrderedFloat;
 
 use crate::{
-    cursor_ext::CursorExt,
+    cursor_ext::{ReadExt, WriteExt},
     error::{DeserializeError, Error, SerializeError},
 };
 

--- a/src/properties/int_property.rs
+++ b/src/properties/int_property.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Debug,
-    io::{Cursor, Read, Write},
+    io::{Cursor, Read, Seek, Write},
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -68,9 +68,9 @@ macro_rules! impl_int_property {
         }
 
         impl PropertyTrait for $name {
-            fn write(
+            fn write<W: Write + Seek>(
                 &self,
-                cursor: &mut Cursor<Vec<u8>>,
+                cursor: &mut W,
                 include_header: bool,
             ) -> Result<(), Error> {
                 if include_header {
@@ -117,7 +117,7 @@ impl Debug for Int8Property {
 }
 
 impl PropertyTrait for Int8Property {
-    fn write(&self, cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<(), Error> {
+    fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             cursor.write_string("Int8Property")?;
             cursor.write_i64::<LittleEndian>(1)?;
@@ -165,7 +165,7 @@ impl Debug for ByteProperty {
 }
 
 impl PropertyTrait for ByteProperty {
-    fn write(&self, cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<(), Error> {
+    fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             cursor.write_string("ByteProperty")?;
             cursor.write_i64::<LittleEndian>(1)?;
@@ -216,7 +216,7 @@ impl Debug for BoolProperty {
 }
 
 impl PropertyTrait for BoolProperty {
-    fn write(&self, cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<(), Error> {
+    fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             cursor.write_string("BoolProperty")?;
             cursor.write_i64::<LittleEndian>(0)?;
@@ -261,7 +261,7 @@ impl Debug for FloatProperty {
 }
 
 impl PropertyTrait for FloatProperty {
-    fn write(&self, cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<(), Error> {
+    fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             cursor.write_string("FloatProperty")?;
             cursor.write_i64::<LittleEndian>(4)?;
@@ -306,7 +306,7 @@ impl Debug for DoubleProperty {
 }
 
 impl PropertyTrait for DoubleProperty {
-    fn write(&self, cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<(), Error> {
+    fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             cursor.write_string("DoubleProperty")?;
             cursor.write_i64::<LittleEndian>(8)?;

--- a/src/properties/int_property.rs
+++ b/src/properties/int_property.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Debug,
-    io::{Cursor, Read, Seek, Write},
+    io::{Read, Seek, Write},
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -21,7 +21,7 @@ macro_rules! check_size {
             Err(DeserializeError::InvalidValueSize(
                 $expected,
                 value_size,
-                $cursor.position(),
+                $cursor.stream_position()?,
             ))?
         }
     };
@@ -47,8 +47,8 @@ macro_rules! impl_int_property {
                 $name { value }
             }
 
-            pub(crate) fn read(
-                cursor: &mut Cursor<Vec<u8>>,
+            pub(crate) fn read<R: Read + Seek>(
+                cursor: &mut R,
                 include_header: bool,
             ) -> Result<Self, Error> {
                 if include_header {
@@ -99,7 +99,10 @@ impl Int8Property {
         Int8Property { value }
     }
 
-    pub(crate) fn read(cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<Self, Error> {
+    pub(crate) fn read<R: Read + Seek>(
+        cursor: &mut R,
+        include_header: bool,
+    ) -> Result<Self, Error> {
         if include_header {
             check_size!(cursor, 1);
             cursor.read_exact(&mut [0u8; 1])?;
@@ -144,7 +147,10 @@ impl ByteProperty {
         ByteProperty { name, value }
     }
 
-    pub(crate) fn read(cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<Self, Error> {
+    pub(crate) fn read<R: Read + Seek>(
+        cursor: &mut R,
+        include_header: bool,
+    ) -> Result<Self, Error> {
         let mut name = None;
         if include_header {
             check_size!(cursor, 1);
@@ -198,7 +204,10 @@ impl BoolProperty {
         }
     }
 
-    pub(crate) fn read(cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<Self, Error> {
+    pub(crate) fn read<R: Read + Seek>(
+        cursor: &mut R,
+        include_header: bool,
+    ) -> Result<Self, Error> {
         let mut indicator = 0u8;
         if include_header {
             check_size!(cursor, 0);
@@ -243,7 +252,10 @@ impl FloatProperty {
         }
     }
 
-    pub(crate) fn read(cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<Self, Error> {
+    pub(crate) fn read<R: Read + Seek>(
+        cursor: &mut R,
+        include_header: bool,
+    ) -> Result<Self, Error> {
         if include_header {
             check_size!(cursor, 4);
             cursor.read_exact(&mut [0u8; 1])?;
@@ -288,7 +300,10 @@ impl DoubleProperty {
         }
     }
 
-    pub(crate) fn read(cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<Self, Error> {
+    pub(crate) fn read<R: Read + Seek>(
+        cursor: &mut R,
+        include_header: bool,
+    ) -> Result<Self, Error> {
         if include_header {
             check_size!(cursor, 8);
             cursor.read_exact(&mut [0u8; 1])?;

--- a/src/properties/map_property.rs
+++ b/src/properties/map_property.rs
@@ -9,7 +9,7 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use indexmap::IndexMap;
 
 use crate::{
-    cursor_ext::CursorExt,
+    cursor_ext::{ReadExt, WriteExt},
     error::{Error, SerializeError},
     scoped_stack_entry::ScopedStackEntry,
 };

--- a/src/properties/map_property.rs
+++ b/src/properties/map_property.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     hash::Hash,
-    io::{Cursor, Read, Seek, SeekFrom, Write},
+    io::{Read, Seek, SeekFrom, Write},
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -47,8 +47,8 @@ impl MapProperty {
         }
     }
 
-    pub(crate) fn read(
-        cursor: &mut Cursor<Vec<u8>>,
+    pub(crate) fn read<R: Read + Seek>(
+        cursor: &mut R,
         hints: &HashMap<String, String>,
         properties_stack: &mut Vec<String>,
     ) -> Result<Self, Error> {

--- a/src/properties/mod.rs
+++ b/src/properties/mod.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     fmt::Debug,
     hash::Hash,
-    io::{Cursor, Seek, Write},
+    io::{Read, Seek, Write},
 };
 
 use enum_dispatch::enum_dispatch;
@@ -127,8 +127,8 @@ pub enum Property {
 
 impl Property {
     /// Creates a new `Property` instance.
-    pub fn new(
-        cursor: &mut Cursor<Vec<u8>>,
+    pub fn new<R: Read + Seek>(
+        cursor: &mut R,
         hints: &HashMap<String, String>,
         properties_stack: &mut Vec<String>,
         value_type: &str,
@@ -159,7 +159,7 @@ impl Property {
                         Err(DeserializeError::MissingHint(
                             value_type.to_string(),
                             struct_path,
-                            cursor.position(),
+                            cursor.stream_position()?,
                         ))?
                     };
 
@@ -195,7 +195,7 @@ impl Property {
 
                 Err(DeserializeError::invalid_property(
                     value_type,
-                    cursor.position(),
+                    cursor.stream_position()?,
                 ))?
             }
         }

--- a/src/properties/mod.rs
+++ b/src/properties/mod.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, fmt::Debug, hash::Hash, io::Cursor};
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    hash::Hash,
+    io::{Cursor, Seek, Write},
+};
 
 use enum_dispatch::enum_dispatch;
 
@@ -66,7 +71,7 @@ macro_rules! make_matcher {
 #[enum_dispatch]
 pub trait PropertyTrait: Debug + Clone + PartialEq + Eq + Hash {
     /// Serialize.
-    fn write(&self, cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<(), Error>;
+    fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error>;
 }
 
 /// GVAS property types.

--- a/src/properties/mod.rs
+++ b/src/properties/mod.rs
@@ -193,10 +193,7 @@ impl Property {
                     .into());
                 }
 
-                Err(DeserializeError::invalid_property(
-                    value_type,
-                    cursor.stream_position()?,
-                ))?
+                Err(DeserializeError::invalid_property(value_type, cursor))?
             }
         }
     }

--- a/src/properties/name_property.rs
+++ b/src/properties/name_property.rs
@@ -2,7 +2,10 @@ use std::io::{Cursor, Read, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
-use crate::{cursor_ext::CursorExt, error::Error};
+use crate::{
+    cursor_ext::{ReadExt, WriteExt},
+    error::Error,
+};
 
 use super::PropertyTrait;
 

--- a/src/properties/name_property.rs
+++ b/src/properties/name_property.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Read, Write};
+use std::io::{Cursor, Read, Seek, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
@@ -29,7 +29,7 @@ impl NameProperty {
 }
 
 impl PropertyTrait for NameProperty {
-    fn write(&self, cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<(), Error> {
+    fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             cursor.write_string("NameProperty")?;
             let property_length = self.value.len() + 1 + 4; // 1 is null-byte, 4 is string length field size

--- a/src/properties/name_property.rs
+++ b/src/properties/name_property.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Read, Seek, Write};
+use std::io::{Read, Seek, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
@@ -18,7 +18,10 @@ pub struct NameProperty {
 }
 
 impl NameProperty {
-    pub(crate) fn read(cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<Self, Error> {
+    pub(crate) fn read<R: Read + Seek>(
+        cursor: &mut R,
+        include_header: bool,
+    ) -> Result<Self, Error> {
         if include_header {
             let _length = cursor.read_u64::<LittleEndian>()?;
             cursor.read_exact(&mut [0u8; 1])?;

--- a/src/properties/set_property.rs
+++ b/src/properties/set_property.rs
@@ -6,7 +6,7 @@ use std::{
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
-    cursor_ext::CursorExt,
+    cursor_ext::{ReadExt, WriteExt},
     error::{Error, SerializeError},
 };
 

--- a/src/properties/set_property.rs
+++ b/src/properties/set_property.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    io::{Cursor, Read, Seek, SeekFrom, Write},
+    io::{Read, Seek, SeekFrom, Write},
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -34,8 +34,8 @@ impl SetProperty {
         }
     }
 
-    pub(crate) fn read(
-        cursor: &mut Cursor<Vec<u8>>,
+    pub(crate) fn read<R: Read + Seek>(
+        cursor: &mut R,
         hints: &HashMap<String, String>,
         properties_stack: &mut Vec<String>,
     ) -> Result<Self, Error> {

--- a/src/properties/str_property.rs
+++ b/src/properties/str_property.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Read, Write};
+use std::io::{Cursor, Read, Seek, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use unreal_helpers::{UnrealReadExt, UnrealWriteExt};
@@ -38,7 +38,7 @@ impl StrProperty {
 }
 
 impl PropertyTrait for StrProperty {
-    fn write(&self, cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<(), Error> {
+    fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             cursor.write_string("StrProperty")?;
             let property_length = match &self.value {

--- a/src/properties/str_property.rs
+++ b/src/properties/str_property.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Read, Seek, Write};
+use std::io::{Read, Seek, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use unreal_helpers::{UnrealReadExt, UnrealWriteExt};
@@ -27,7 +27,10 @@ impl StrProperty {
         StrProperty { value }
     }
 
-    pub(crate) fn read(cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<Self, Error> {
+    pub(crate) fn read<R: Read + Seek>(
+        cursor: &mut R,
+        include_header: bool,
+    ) -> Result<Self, Error> {
         if include_header {
             let _length = cursor.read_u64::<LittleEndian>()?;
             cursor.read_exact(&mut [0u8; 1])?;

--- a/src/properties/str_property.rs
+++ b/src/properties/str_property.rs
@@ -3,7 +3,7 @@ use std::io::{Cursor, Read, Write};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use unreal_helpers::{UnrealReadExt, UnrealWriteExt};
 
-use crate::{cursor_ext::CursorExt, error::Error};
+use crate::{cursor_ext::WriteExt, error::Error};
 
 use super::PropertyTrait;
 

--- a/src/properties/struct_property.rs
+++ b/src/properties/struct_property.rs
@@ -8,7 +8,7 @@ use std::{
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
-    cursor_ext::CursorExt,
+    cursor_ext::{ReadExt, WriteExt},
     error::{DeserializeError, Error},
     make_matcher,
     scoped_stack_entry::ScopedStackEntry,

--- a/src/properties/struct_property.rs
+++ b/src/properties/struct_property.rs
@@ -72,10 +72,7 @@ impl StructProperty {
             true => cursor.read_string()?,
             false => match type_name {
                 Some(t) => t,
-                None => Err(DeserializeError::missing_argument(
-                    "type_name",
-                    cursor.stream_position()?,
-                ))?,
+                None => Err(DeserializeError::missing_argument("type_name", cursor))?,
             },
         };
 

--- a/src/properties/struct_property.rs
+++ b/src/properties/struct_property.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     fmt::Debug,
     hash::Hash,
-    io::{Cursor, Read, Seek, SeekFrom, Write},
+    io::{Read, Seek, SeekFrom, Write},
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -57,8 +57,8 @@ impl StructProperty {
         StructProperty { guid, value }
     }
 
-    fn read(
-        cursor: &mut Cursor<Vec<u8>>,
+    fn read<R: Read + Seek>(
+        cursor: &mut R,
         hints: &HashMap<String, String>,
         properties_stack: &mut Vec<String>,
         include_header: bool,
@@ -145,16 +145,16 @@ impl StructProperty {
         })
     }
 
-    pub(crate) fn read_with_header(
-        cursor: &mut Cursor<Vec<u8>>,
+    pub(crate) fn read_with_header<R: Read + Seek>(
+        cursor: &mut R,
         hints: &HashMap<String, String>,
         properties_stack: &mut Vec<String>,
     ) -> Result<Self, Error> {
         Self::read(cursor, hints, properties_stack, true, None)
     }
 
-    pub(crate) fn read_with_type_name(
-        cursor: &mut Cursor<Vec<u8>>,
+    pub(crate) fn read_with_type_name<R: Read + Seek>(
+        cursor: &mut R,
         hints: &HashMap<String, String>,
         properties_stack: &mut Vec<String>,
         type_name: &str,

--- a/src/properties/text_property.rs
+++ b/src/properties/text_property.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, io::Cursor};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
-    cursor_ext::CursorExt,
+    cursor_ext::{ReadExt, WriteExt},
     error::{DeserializeError, Error, SerializeError},
 };
 

--- a/src/properties/text_property.rs
+++ b/src/properties/text_property.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Debug,
-    io::{Cursor, Seek, Write},
+    io::{Read, Seek, Write},
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -71,7 +71,10 @@ impl TextProperty {
         }
     }
 
-    pub(crate) fn read(cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<Self, Error> {
+    pub(crate) fn read<R: Read + Seek>(
+        cursor: &mut R,
+        include_header: bool,
+    ) -> Result<Self, Error> {
         validate!(
             cursor,
             !include_header,

--- a/src/properties/text_property.rs
+++ b/src/properties/text_property.rs
@@ -1,4 +1,7 @@
-use std::{fmt::Debug, io::Cursor};
+use std::{
+    fmt::Debug,
+    io::{Cursor, Seek, Write},
+};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
@@ -50,7 +53,7 @@ macro_rules! validate {
         if !$cond {
             Err(DeserializeError::InvalidProperty(
                 format!($($arg)+),
-                $cursor.position(),
+                $cursor.stream_position()?,
             ))?
         }
     }};
@@ -154,7 +157,7 @@ impl TextProperty {
             // Unknown text
             Err(DeserializeError::InvalidProperty(
                 format!("Unexpected component_type {}", component_type),
-                cursor.position(),
+                cursor.stream_position()?,
             ))?
         }
     }
@@ -171,7 +174,7 @@ impl Debug for TextProperty {
 }
 
 impl PropertyTrait for TextProperty {
-    fn write(&self, cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<(), Error> {
+    fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             return Err(
                 SerializeError::invalid_value("TextProperty only supported in arrays").into(),

--- a/src/properties/unknown_property.rs
+++ b/src/properties/unknown_property.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Read, Seek, Write};
+use std::io::{Read, Seek, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
@@ -20,8 +20,8 @@ impl UnknownProperty {
         UnknownProperty { property_name, raw }
     }
 
-    pub(crate) fn read_with_length(
-        cursor: &mut Cursor<Vec<u8>>,
+    pub(crate) fn read_with_length<R: Read + Seek>(
+        cursor: &mut R,
         property_name: String,
         length: u64,
     ) -> Result<Self, Error> {
@@ -34,8 +34,8 @@ impl UnknownProperty {
         })
     }
 
-    pub(crate) fn read_with_header(
-        cursor: &mut Cursor<Vec<u8>>,
+    pub(crate) fn read_with_header<R: Read + Seek>(
+        cursor: &mut R,
         property_name: String,
     ) -> Result<Self, Error> {
         let length = cursor.read_u64::<LittleEndian>()?;

--- a/src/properties/unknown_property.rs
+++ b/src/properties/unknown_property.rs
@@ -2,7 +2,7 @@ use std::io::{Cursor, Read, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
-use crate::{cursor_ext::CursorExt, error::Error};
+use crate::{cursor_ext::WriteExt, error::Error};
 
 use super::PropertyTrait;
 

--- a/src/properties/unknown_property.rs
+++ b/src/properties/unknown_property.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Read, Write};
+use std::io::{Cursor, Read, Seek, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
@@ -52,7 +52,7 @@ impl UnknownProperty {
 }
 
 impl PropertyTrait for UnknownProperty {
-    fn write(&self, cursor: &mut Cursor<Vec<u8>>, include_header: bool) -> Result<(), Error> {
+    fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             cursor.write_string(&self.property_name)?;
             cursor.write_u64::<LittleEndian>(self.raw.len() as u64)?;

--- a/tests/features_01.rs
+++ b/tests/features_01.rs
@@ -110,15 +110,9 @@ fn read_features_01() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("resources/test/features_01.bin");
     let mut file = File::open(path).expect("Failed to open test asset");
 
-    // Read the file in to a Vec<u8>
-    let mut data = Vec::new();
-    file.read_to_end(&mut data)
-        .expect("Failed to read test asset");
-
-    // Convert the Vec<u8> to a GvasFile
-    let mut cursor = Cursor::new(data);
+    // Read the file in to a GvasFile
     let hints = get_hints();
-    GvasFile::read_with_hints(&mut cursor, &hints).expect("Failed to parse gvas file");
+    GvasFile::read_with_hints(&mut file, &hints).expect("Failed to parse gvas file");
 }
 
 #[test]

--- a/tests/saveslot_03.rs
+++ b/tests/saveslot_03.rs
@@ -46,15 +46,9 @@ fn read_save_slot_03() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("resources/test/SaveSlot_03.sav");
     let mut file = File::open(path).expect("Failed to open test asset");
 
-    // Read the file in to a Vec<u8>
-    let mut data = Vec::new();
-    file.read_to_end(&mut data)
-        .expect("Failed to read test asset");
-
-    // Convert the Vec<u8> to a GvasFile
-    let mut cursor = Cursor::new(data);
+    // Read the file in to a GvasFile
     let hints = get_hints();
-    let file = GvasFile::read_with_hints(&mut cursor, &hints).expect("Failed to parse gvas file");
+    let file = GvasFile::read_with_hints(&mut file, &hints).expect("Failed to parse gvas file");
 
     assert_eq!(
         file.header,

--- a/tests/slot2.rs
+++ b/tests/slot2.rs
@@ -10,14 +10,8 @@ fn read_slot2() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("resources/test/Slot2.sav");
     let mut file = File::open(path).expect("Failed to open test asset");
 
-    // Read the file in to a Vec<u8>
-    let mut data = Vec::new();
-    file.read_to_end(&mut data)
-        .expect("Failed to read test asset");
-
-    // Convert the Vec<u8> to a GvasFile
-    let mut cursor = Cursor::new(data);
-    GvasFile::read(&mut cursor).expect("Failed to parse gvas file");
+    // Read the file in to a GvasFile
+    let _gvas = GvasFile::read(&mut file).expect("Failed to parse gvas file");
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -154,14 +154,8 @@ fn read_file() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("resources/test/Slot1.sav");
     let mut file = File::open(path).expect("Failed to open test asset");
 
-    // Read the file in to a Vec<u8>
-    let mut data = Vec::new();
-    file.read_to_end(&mut data)
-        .expect("Failed to read test asset");
-
-    // Convert the Vec<u8> to a GvasFile
-    let mut cursor = Cursor::new(data);
-    let file = GvasFile::read(&mut cursor).expect("Failed to parse gvas file");
+    // Read the file in to a GvasFile
+    let file = GvasFile::read(&mut file).expect("Failed to parse gvas file");
 
     // Verify GvasFile contents
     verify_file_data(&file);

--- a/tests/test_cursor.rs
+++ b/tests/test_cursor.rs
@@ -1,6 +1,9 @@
 use std::io::Cursor;
 
-use gvas::{cursor_ext::CursorExt, error::Error};
+use gvas::{
+    cursor_ext::{ReadExt, WriteExt},
+    error::Error,
+};
 
 #[test]
 fn test_write_string() -> Result<(), Error> {

--- a/tests/test_property.rs
+++ b/tests/test_property.rs
@@ -3,7 +3,7 @@ mod test_file;
 use std::{collections::HashMap, io::Cursor};
 
 use gvas::{
-    cursor_ext::CursorExt,
+    cursor_ext::ReadExt,
     properties::{
         array_property::ArrayProperty,
         enum_property::EnumProperty,


### PR DESCRIPTION
- Pass usize from read_fstring() through read_string()
- Use unreal_helpers read_bool/write_bool u8 conversion
- Use Read/Write+Seek traits instead of Cursor for property read/write()
- Update error helpers to operate over the Seek trait
- Update docs and tests to read directly from files without a Cursor