### PR TITLE
Simplify EnumProperty

### DIFF
--- a/tests/test_property.rs
+++ b/tests/test_property.rs
@@ -80,7 +80,7 @@ test_property!(test_str, StrProperty, StrProperty::from("test string"));
 test_property!(
     test_enum,
     EnumProperty,
-    EnumProperty::new("type".into(), "value".into(), true)
+    EnumProperty::new(String::from("type"), String::from("value"))
 );
 
 // StructProperty


### PR DESCRIPTION
The `compact_name` feature does not appear to be implemented correctly, and does not have any test cases associated with it