### PR TITLE
Tweaks to serde structure

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,9 +52,21 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-targets --all-features --verbose --workspace
+          args: --all-targets --verbose --workspace
 
       - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-targets --verbose --workspace
+
+      - name: Build --all-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-targets --all-features --verbose --workspace
+
+      - name: Test --all-features
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/src/properties/array_property.rs
+++ b/src/properties/array_property.rs
@@ -19,6 +19,8 @@ use super::{struct_property::StructProperty, Property, PropertyTrait};
 struct ArrayStructInfo {
     type_name: String,
     field_name: String,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Guid::is_zero"))]
+    #[cfg_attr(feature = "serde", serde(default))]
     guid: Guid,
 }
 
@@ -31,6 +33,7 @@ pub struct ArrayProperty {
     /// An array of values.
     pub properties: Vec<Property>,
 
+    #[cfg_attr(feature = "serde", serde(flatten))]
     array_struct_info: Option<ArrayStructInfo>,
 }
 

--- a/src/properties/struct_property.rs
+++ b/src/properties/struct_property.rs
@@ -26,8 +26,11 @@ use super::{
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StructProperty {
     /// The unique identifier of the property.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Guid::is_zero"))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub guid: Guid,
     /// The value of the property.
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub value: StructPropertyValue,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,13 +5,18 @@ use std::{
 };
 
 /// Stores a 128-bit guid (globally unique identifier)
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Default, PartialEq, Eq, Hash)]
 pub struct Guid(pub [u8; 16]);
 
 impl Guid {
     /// Create new instance of Guid struct from a [0u8; 16] byte array
     pub fn new(guid: [u8; 16]) -> Self {
         Guid(guid)
+    }
+
+    /// Returns true if the guid is zero.
+    pub fn is_zero(&self) -> bool {
+        self.0.iter().all(|&x| x == 0)
     }
 }
 
@@ -117,7 +122,7 @@ impl Debug for Guid {
 
 impl Display for Guid {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.0.iter().all(|&x| x == 0) {
+        if self.is_zero() {
             write!(f, "0")?;
             return Ok(());
         }


### PR DESCRIPTION
- Modify serde annotations to so the output is more compact
- Update the workflow to check for default features, to ensure that naked `#[serde(...)]` statements will fail status checks
- Work around a deserialization bug with empty enum tuple types