### PR TITLE
Prefer unsigned lengths and sentinel values, cleanup tests, simplify struct serialization

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,13 +8,13 @@ use unreal_helpers::error::FStringError;
 pub enum DeserializeError {
     /// If the file header is not GVAS
     #[error("Invalid file type {0}")]
-    InvalidFileType(i32),
+    InvalidFileType(u32),
     /// If a value has a size that was unexpected, e.g. UInt32Property has 8 bytes size
     #[error("Invalid value size, expected {0} got {1} at position {2}")]
     InvalidValueSize(u64, u64, u64),
     /// If a string has invalid size
     #[error("Invalid string size, got {0} at position {1}")]
-    InvalidString(i32, u64),
+    InvalidString(u32, u64),
     /// If a hint is missing.
     #[error("Missing hint for struct {0} at path {1}, cursor position: {2}")]
     MissingHint(String, String, u64),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,12 +154,12 @@ pub struct FCustomVersion {
     /// Key
     pub key: Guid,
     /// Value
-    pub version: i32,
+    pub version: u32,
 }
 
 impl FCustomVersion {
     /// Creates a new instance of `FCustomVersion`
-    pub fn new(key: Guid, version: i32) -> Self {
+    pub fn new(key: Guid, version: u32) -> Self {
         FCustomVersion { key, version }
     }
 
@@ -167,7 +167,7 @@ impl FCustomVersion {
     pub(crate) fn read<R: Read + Seek>(cursor: &mut R) -> Result<Self, Error> {
         let mut guid = [0u8; 16];
         cursor.read_exact(&mut guid)?;
-        let version = cursor.read_i32::<LittleEndian>()?;
+        let version = cursor.read_u32::<LittleEndian>()?;
 
         Ok(FCustomVersion {
             key: Guid::new(guid),
@@ -178,28 +178,28 @@ impl FCustomVersion {
     /// Write FCustomVersion to a binary file
     pub(crate) fn write<W: Write>(&self, cursor: &mut W) -> Result<(), Error> {
         let _ = cursor.write(&self.key.0)?;
-        cursor.write_i32::<LittleEndian>(self.version)?;
+        cursor.write_u32::<LittleEndian>(self.version)?;
         Ok(())
     }
 }
 
 /// The four bytes 'GVAS' appear at the beginning of every GVAS file.
-pub const FILE_TYPE_GVAS: i32 = i32::from_le_bytes([b'G', b'V', b'A', b'S']);
+pub const FILE_TYPE_GVAS: u32 = u32::from_le_bytes([b'G', b'V', b'A', b'S']);
 
 /// Stores information about GVAS file, engine version, etc.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GvasHeader {
     /// The literal 'GVAS'.
-    pub file_type_tag: i32,
+    pub file_type_tag: u32,
     /// Save game file version.
-    pub save_game_file_version: i32,
+    pub save_game_file_version: u32,
     /// File format version.
-    pub package_file_ue4_version: i32,
+    pub package_file_ue4_version: u32,
     /// Unreal Engine version.
     pub engine_version: FEngineVersion,
     /// Custom version format.
-    pub custom_version_format: i32,
+    pub custom_version_format: u32,
     /// Custom versions.
     pub custom_versions: Vec<FCustomVersion>,
     /// Save game class name.
@@ -209,11 +209,11 @@ pub struct GvasHeader {
 impl GvasHeader {
     /// Creates a new instance of `GvasHeader`
     pub fn new(
-        file_type_tag: i32,
-        save_game_file_version: i32,
-        package_file_ue4_version: i32,
+        file_type_tag: u32,
+        save_game_file_version: u32,
+        package_file_ue4_version: u32,
         engine_version: FEngineVersion,
-        custom_version_format: i32,
+        custom_version_format: u32,
         custom_versions: Vec<FCustomVersion>,
         save_game_class_name: String,
     ) -> Self {
@@ -250,16 +250,16 @@ impl GvasHeader {
     /// # Ok::<(), Error>(())
     /// ```
     pub fn read<R: Read + Seek>(cursor: &mut R) -> Result<Self, Error> {
-        let file_type_tag = cursor.read_i32::<LittleEndian>()?;
+        let file_type_tag = cursor.read_u32::<LittleEndian>()?;
         if file_type_tag != FILE_TYPE_GVAS {
             Err(DeserializeError::InvalidFileType(file_type_tag))?
         }
-        let save_game_file_version = cursor.read_i32::<LittleEndian>()?;
-        let package_file_ue4_version = cursor.read_i32::<LittleEndian>()?;
+        let save_game_file_version = cursor.read_u32::<LittleEndian>()?;
+        let package_file_ue4_version = cursor.read_u32::<LittleEndian>()?;
         let engine_version = FEngineVersion::read(cursor)?;
-        let custom_version_format = cursor.read_i32::<LittleEndian>()?;
+        let custom_version_format = cursor.read_u32::<LittleEndian>()?;
 
-        let custom_versions_len = cursor.read_i32::<LittleEndian>()? as usize;
+        let custom_versions_len = cursor.read_u32::<LittleEndian>()? as usize;
         let mut custom_versions = Vec::with_capacity(custom_versions_len);
         for _ in 0..custom_versions_len {
             custom_versions.push(FCustomVersion::read(cursor)?);
@@ -297,12 +297,12 @@ impl GvasHeader {
     /// # Ok::<(), Error>(())
     /// ```
     pub fn write<W: Write>(&self, cursor: &mut W) -> Result<(), Error> {
-        cursor.write_i32::<LittleEndian>(self.file_type_tag)?;
-        cursor.write_i32::<LittleEndian>(self.save_game_file_version)?;
-        cursor.write_i32::<LittleEndian>(self.package_file_ue4_version)?;
+        cursor.write_u32::<LittleEndian>(self.file_type_tag)?;
+        cursor.write_u32::<LittleEndian>(self.save_game_file_version)?;
+        cursor.write_u32::<LittleEndian>(self.package_file_ue4_version)?;
         self.engine_version.write(cursor)?;
-        cursor.write_i32::<LittleEndian>(self.custom_version_format)?;
-        cursor.write_i32::<LittleEndian>(self.custom_versions.len() as i32)?;
+        cursor.write_u32::<LittleEndian>(self.custom_version_format)?;
+        cursor.write_u32::<LittleEndian>(self.custom_versions.len() as u32)?;
 
         for custom_version in &self.custom_versions {
             custom_version.write(cursor)?;

--- a/src/properties/array_property.rs
+++ b/src/properties/array_property.rs
@@ -80,7 +80,7 @@ impl ArrayProperty {
         cursor.read_exact(&mut [0u8; 1])?;
         let start_position = cursor.stream_position()?;
 
-        let property_count = cursor.read_i32::<LittleEndian>()? as usize;
+        let property_count = cursor.read_u32::<LittleEndian>()? as usize;
         let mut properties: Vec<Property> = Vec::with_capacity(property_count);
 
         let mut array_struct_info = None;
@@ -163,10 +163,10 @@ impl PropertyTrait for ArrayProperty {
         cursor.write_u64::<LittleEndian>(0)?;
 
         cursor.write_string(&self.property_type)?;
-        let _ = cursor.write(&[0u8; 1])?;
+        cursor.write_u8(0)?;
         let begin_write = cursor.stream_position()?;
 
-        cursor.write_i32::<LittleEndian>(self.properties.len() as i32)?;
+        cursor.write_u32::<LittleEndian>(self.properties.len() as u32)?;
 
         match self.property_type.as_str() {
             "StructProperty" => {
@@ -183,7 +183,7 @@ impl PropertyTrait for ArrayProperty {
                 cursor.write_u64::<LittleEndian>(0)?;
                 cursor.write_string(&array_struct_info.type_name)?;
                 let _ = cursor.write(&array_struct_info.guid.0)?;
-                let _ = cursor.write(&[0u8; 1])?;
+                cursor.write_u8(0)?;
                 let begin_without_name = cursor.stream_position()?;
 
                 for property in &self.properties {

--- a/src/properties/enum_property.rs
+++ b/src/properties/enum_property.rs
@@ -53,7 +53,7 @@ impl PropertyTrait for EnumProperty {
         cursor.write_u64::<LittleEndian>(0)?;
 
         cursor.write_string(&self.enum_type)?;
-        cursor.write_all(&[0u8; 1])?;
+        cursor.write_u8(0)?;
 
         let value_begin = cursor.stream_position()?;
         cursor.write_string(&self.value)?;

--- a/src/properties/int_property.rs
+++ b/src/properties/int_property.rs
@@ -76,7 +76,7 @@ macro_rules! impl_int_property {
                 if include_header {
                     cursor.write_string(stringify!($name))?;
                     cursor.write_i64::<LittleEndian>($size)?;
-                    let _ = cursor.write(&[0u8; 1])?;
+                    cursor.write_u8(0)?;
                 }
                 cursor.$write_method::<LittleEndian>(self.value)?;
                 Ok(())
@@ -123,8 +123,8 @@ impl PropertyTrait for Int8Property {
     fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             cursor.write_string("Int8Property")?;
-            cursor.write_i64::<LittleEndian>(1)?;
-            let _ = cursor.write(&[0u8; 1])?;
+            cursor.write_u64::<LittleEndian>(1)?;
+            cursor.write_u8(0)?;
         }
         cursor.write_i8(self.value)?;
         Ok(())
@@ -174,11 +174,11 @@ impl PropertyTrait for ByteProperty {
     fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             cursor.write_string("ByteProperty")?;
-            cursor.write_i64::<LittleEndian>(1)?;
+            cursor.write_u64::<LittleEndian>(1)?;
             cursor.write_string(self.name.as_ref().ok_or_else(|| {
                 SerializeError::InvalidValue(String::from("self.name None expected Some(...)"))
             })?)?;
-            let _ = cursor.write(&[0u8; 1])?;
+            cursor.write_u8(0)?;
         }
         cursor.write_u8(self.value)?;
         Ok(())
@@ -228,7 +228,7 @@ impl PropertyTrait for BoolProperty {
     fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             cursor.write_string("BoolProperty")?;
-            cursor.write_i64::<LittleEndian>(0)?;
+            cursor.write_u64::<LittleEndian>(0)?;
             cursor.write_u8(self.indicator)?;
         }
         cursor.write_bool(self.value)?;
@@ -276,8 +276,8 @@ impl PropertyTrait for FloatProperty {
     fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             cursor.write_string("FloatProperty")?;
-            cursor.write_i64::<LittleEndian>(4)?;
-            let _ = cursor.write(&[0u8; 1])?;
+            cursor.write_u64::<LittleEndian>(4)?;
+            cursor.write_u8(0)?;
         }
         cursor.write_f32::<LittleEndian>(self.value.0)?;
         Ok(())
@@ -324,8 +324,8 @@ impl PropertyTrait for DoubleProperty {
     fn write<W: Write + Seek>(&self, cursor: &mut W, include_header: bool) -> Result<(), Error> {
         if include_header {
             cursor.write_string("DoubleProperty")?;
-            cursor.write_i64::<LittleEndian>(8)?;
-            let _ = cursor.write(&[0u8; 1])?;
+            cursor.write_u64::<LittleEndian>(8)?;
+            cursor.write_u8(0)?;
         }
         cursor.write_f64::<LittleEndian>(self.value.0)?;
         Ok(())

--- a/src/properties/map_property.rs
+++ b/src/properties/map_property.rs
@@ -60,7 +60,7 @@ impl MapProperty {
         cursor.read_exact(&mut [0u8; 1])?;
 
         let allocation_flags = cursor.read_u32::<LittleEndian>()?;
-        let element_count = cursor.read_i32::<LittleEndian>()?;
+        let element_count = cursor.read_u32::<LittleEndian>()?;
 
         let mut map = IndexMap::new();
         for _ in 0..element_count {
@@ -100,10 +100,10 @@ impl PropertyTrait for MapProperty {
         cursor.write_string(&self.key_type)?;
         cursor.write_string(&self.value_type)?;
 
-        cursor.write_all(&[0u8; 1])?;
+        cursor.write_u8(0)?;
 
         cursor.write_u32::<LittleEndian>(self.allocation_flags)?;
-        cursor.write_i32::<LittleEndian>(self.value.len() as i32)?;
+        cursor.write_u32::<LittleEndian>(self.value.len() as u32)?;
 
         let write_begin = cursor.stream_position()?;
 

--- a/src/properties/name_property.rs
+++ b/src/properties/name_property.rs
@@ -36,8 +36,8 @@ impl PropertyTrait for NameProperty {
         if include_header {
             cursor.write_string("NameProperty")?;
             let property_length = self.value.len() + 1 + 4; // 1 is null-byte, 4 is string length field size
-            cursor.write_i64::<LittleEndian>(property_length as i64)?;
-            let _ = cursor.write(&[0u8; 1])?;
+            cursor.write_u64::<LittleEndian>(property_length as u64)?;
+            cursor.write_u8(0)?;
         }
 
         cursor.write_string(&self.value)?;

--- a/src/properties/set_property.rs
+++ b/src/properties/set_property.rs
@@ -46,7 +46,7 @@ impl SetProperty {
 
         let allocation_flags = cursor.read_u32::<LittleEndian>()?;
 
-        let element_count = cursor.read_i32::<LittleEndian>()? as usize;
+        let element_count = cursor.read_u32::<LittleEndian>()? as usize;
         let mut properties: Vec<Property> = Vec::with_capacity(element_count);
 
         let total_bytes_per_property = (length - 8) / element_count as u64;
@@ -88,12 +88,12 @@ impl PropertyTrait for SetProperty {
         cursor.write_u64::<LittleEndian>(0)?;
 
         cursor.write_string(&self.property_type)?;
-        let _ = cursor.write(&[0u8; 1])?;
+        cursor.write_u8(0)?;
 
         let set_begin = cursor.stream_position()?;
 
         cursor.write_u32::<LittleEndian>(self.allocation_flags)?;
-        cursor.write_i32::<LittleEndian>(self.properties.len() as i32)?;
+        cursor.write_u32::<LittleEndian>(self.properties.len() as u32)?;
 
         for property in &self.properties {
             property.write(cursor, false)?;

--- a/src/properties/str_property.rs
+++ b/src/properties/str_property.rs
@@ -48,8 +48,8 @@ impl PropertyTrait for StrProperty {
                 Some(value) => value.len() + 1 + 4, // 1 is null-byte, 4 is string length field size
                 None => 4,                          // 4 is string length field size
             };
-            cursor.write_i64::<LittleEndian>(property_length as i64)?;
-            let _ = cursor.write(&[0u8; 1])?;
+            cursor.write_u64::<LittleEndian>(property_length as u64)?;
+            cursor.write_u8(0)?;
         }
 
         cursor.write_fstring(self.value.as_deref())?;

--- a/src/properties/struct_property.rs
+++ b/src/properties/struct_property.rs
@@ -187,7 +187,7 @@ impl PropertyTrait for StructProperty {
                 StructPropertyValue::CustomStruct(type_name, _) => type_name,
             })?;
             cursor.write_all(&self.guid.0)?;
-            cursor.write_all(&[0u8; 1])?;
+            cursor.write_u8(0)?;
             write_begin = cursor.stream_position()?;
         }
 

--- a/src/properties/text_property.rs
+++ b/src/properties/text_property.rs
@@ -217,7 +217,7 @@ impl PropertyTrait for TextProperty {
             TextProperty::Simple(values) => {
                 cursor.write_u32::<LittleEndian>(2)?;
                 cursor.write_u8(255)?;
-                cursor.write_i32::<LittleEndian>(values.len() as i32)?;
+                cursor.write_u32::<LittleEndian>(values.len() as u32)?;
                 for value in values {
                     cursor.write_string(value)?;
                 }

--- a/src/properties/unknown_property.rs
+++ b/src/properties/unknown_property.rs
@@ -56,7 +56,7 @@ impl PropertyTrait for UnknownProperty {
         if include_header {
             cursor.write_string(&self.property_name)?;
             cursor.write_u64::<LittleEndian>(self.raw.len() as u64)?;
-            cursor.write_all(&[0u8; 1])?;
+            cursor.write_u8(0)?;
         }
 
         cursor.write_all(&self.raw)?;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -105,7 +105,7 @@ fn verify_file_data(file: &GvasFile) {
                         String::from("CustomStruct"),
                         vec![(
                             String::from("test_field"),
-                            UInt64Property { value: 10 }.into()
+                            Property::from(UInt64Property::new(10))
                         )]
                     )
                 }),
@@ -115,7 +115,7 @@ fn verify_file_data(file: &GvasFile) {
                         String::from("CustomStruct"),
                         vec![(
                             String::from("test_field"),
-                            UInt64Property { value: 10 }.into()
+                            Property::from(UInt64Property::new(10))
                         )]
                     )
                 }),

--- a/tests/test_property.rs
+++ b/tests/test_property.rs
@@ -35,7 +35,7 @@ macro_rules! test_property {
             let mut writer = Cursor::new(Vec::new());
             property
                 .write(&mut writer, true)
-                .expect(&format!("Failed to serialize {}", stringify!($ty)));
+                .expect(concat!("Failed to serialize {}", stringify!($ty)));
 
             // Import the property from a byte array
             let mut reader = Cursor::new(writer.get_ref().to_owned());
@@ -63,7 +63,7 @@ test_property!(test_int8, Int8Property, Int8Property::new(i8::MAX));
 test_property!(
     test_byte,
     ByteProperty,
-    ByteProperty::new(Some("Test ByteProperty".into()), u8::MAX)
+    ByteProperty::new(Some(String::from("Test ByteProperty")), u8::MAX)
 );
 test_property!(test_int16, Int16Property, Int16Property::new(i16::MAX));
 test_property!(test_uint16, UInt16Property, UInt16Property::new(u16::MAX));
@@ -94,14 +94,14 @@ test_property!(
 test_property!(
     test_array_empty,
     ArrayProperty,
-    ArrayProperty::new("FloatProperty".into(), None, vec![],)
+    ArrayProperty::new(String::from("FloatProperty"), None, vec![],)
 );
 
 test_property!(
     test_array_float,
     ArrayProperty,
     ArrayProperty::new(
-        "FloatProperty".into(),
+        String::from("FloatProperty"),
         None,
         vec![
             Property::from(FloatProperty::new(0f32)),
@@ -114,8 +114,12 @@ test_property!(
     test_array_vector,
     ArrayProperty,
     ArrayProperty::new(
-        "StructProperty".into(),
-        Some(("FieldName".to_string(), "Vector".into(), Guid::from(0u128))),
+        String::from("StructProperty"),
+        Some((
+            "FieldName".to_string(),
+            String::from("Vector"),
+            Guid::from(0u128)
+        )),
         vec![
             Property::from(StructProperty::from(Vector::new(0f32, 1f32, 2f32))),
             Property::from(StructProperty::from(Vector::new(3f32, 4f32, 5f32))),
@@ -128,22 +132,22 @@ test_property!(
     test_array_text,
     ArrayProperty,
     ArrayProperty::new(
-        "TextProperty".into(),
+        String::from("TextProperty"),
         None,
         vec![
             Property::from(TextProperty::new(None, None)),
             Property::from(TextProperty::new(
                 Some(RichText::new(
-                    "identifier".into(),
-                    "{0}<br>{1}".into(),
+                    String::from("identifier"),
+                    String::from("{0}<br>{1}"),
                     vec![
-                        RichTextFormat::new("0".into(), 0, vec!["line1".into()]),
-                        RichTextFormat::new("1".into(), 0, vec!["line2".into()]),
+                        RichTextFormat::new(String::from("0"), 0, vec![String::from("line1")]),
+                        RichTextFormat::new(String::from("1"), 0, vec![String::from("line2")]),
                     ]
                 )),
                 None
             )),
-            Property::from(TextProperty::new(None, Some(vec!["String".into()]))),
+            Property::from(TextProperty::new(None, Some(vec![String::from("String")]))),
         ]
     )
 );
@@ -153,7 +157,7 @@ test_property!(
     test_set,
     SetProperty,
     SetProperty::new(
-        "FloatProperty".into(),
+        String::from("FloatProperty"),
         0,
         vec![Property::from(FloatProperty::new(4321f32))]
     )
@@ -164,8 +168,8 @@ test_property!(
     test_map,
     MapProperty,
     MapProperty::new(
-        "StrProperty".into(),
-        "FloatProperty".into(),
+        String::from("StrProperty"),
+        String::from("FloatProperty"),
         0,
         IndexMap::from([
             (


### PR DESCRIPTION
- Review after #23
- Prefer `::from` over `.into()`
- Simplify struct serialization
- Prefer unsigned lengths and sentinel values