### PR TITLE
Support big endian hosts, add cross-test workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,3 +61,44 @@ jobs:
 
       - name: Clippy
         run: cargo clippy --all-features --all-targets -- -D warnings
+
+  cross-test:
+    name: cross / ${{ matrix.arch }}
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        toolchain:
+          - stable
+        arch:
+          - i686-unknown-linux-gnu
+          - powerpc-unknown-linux-gnu
+          - powerpc64le-unknown-linux-gnu
+          - riscv64gc-unknown-linux-gnu
+          - s390x-unknown-linux-gnu
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+            ~/.rustup
+          key: ${{ runner.os }}-${{ matrix.toolchain }}
+
+      - name: Install Rust ${{ matrix.toolchain }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          targets: ${{ matrix.arch }}
+
+      - run: cargo install cross
+      - run: cross build --target ${{ matrix.arch }}
+      - run: cross test --target ${{ matrix.arch }}
+      - run: cross build --target ${{ matrix.arch }} --all-features
+      - run: cross test --target ${{ matrix.arch }} --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ ordered-float = "4.2.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_with = { version = "3.5", optional = true, features = ["hex"] }
 indexmap = "2.2.1"
-unreal_helpers = { version = "0.1.13", features = ["read_write"] }
 thiserror = "1.0.40"
 num_enum = "0.7.1"
 flate2 = "1.0.28"

--- a/src/cursor_ext.rs
+++ b/src/cursor_ext.rs
@@ -1,7 +1,6 @@
 use std::io::{Read, Seek, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use unreal_helpers::{UnrealReadExt, UnrealWriteExt};
 
 use crate::{
     error::{DeserializeError, Error},
@@ -12,8 +11,12 @@ use crate::{
 pub trait ReadExt {
     /// Reads a GVAS string.
     fn read_string(&mut self) -> Result<String, Error>;
+    /// Reads a GVAS string.
+    fn read_fstring(&mut self) -> Result<Option<String>, Error>;
     /// Reads a GUID.
     fn read_guid(&mut self) -> Result<Guid, Error>;
+    /// Reads an 8bit boolean value.
+    fn read_bool(&mut self) -> Result<bool, Error>;
     /// Reads a 32bit boolean value.
     fn read_b32(&mut self) -> Result<bool, Error>;
     /// Reads an 8bit enum value.
@@ -26,8 +29,12 @@ pub trait ReadExt {
 pub trait WriteExt {
     /// Writes a GVAS string.
     fn write_string<T: AsRef<str>>(&mut self, v: T) -> Result<usize, Error>;
+    /// Writes a GVAS string.
+    fn write_fstring(&mut self, v: Option<&str>) -> Result<usize, Error>;
     /// Writes a GUID.
     fn write_guid(&mut self, v: &Guid) -> Result<(), Error>;
+    /// Writes an 8bit boolean value.
+    fn write_bool(&mut self, v: bool) -> Result<(), Error>;
     /// Writes a 32bit boolean value.
     fn write_b32(&mut self, v: bool) -> Result<(), Error>;
     /// Writes an 8bit enum value.
@@ -45,11 +52,69 @@ impl<R: Read + Seek> ReadExt for R {
         }
     }
 
+    fn read_fstring(&mut self) -> Result<Option<String>, Error> {
+        let start_position = self.stream_position()?;
+        let len = self.read_i32::<LittleEndian>()?;
+
+        if !(-131072..=131072).contains(&len) {
+            Err(DeserializeError::InvalidString(
+                len,
+                self.stream_position()?,
+            ))?
+        } else if len == 0 {
+            Ok(None)
+        } else if len < 0 {
+            let mut buf = vec![0u16; -len as usize - 1];
+            self.read_u16_into::<LittleEndian>(&mut buf)?;
+
+            let terminator = self.read_u16::<LittleEndian>()?;
+            if terminator != 0 {
+                Err(DeserializeError::InvalidStringTerminator(
+                    terminator,
+                    self.stream_position()?,
+                ))?
+            }
+
+            let string = String::from_utf16(&buf[..])
+                .map_err(|e| DeserializeError::FromUtf16Error(e, start_position))?;
+
+            Ok(Some(string))
+        } else {
+            let mut buf = vec![0u8; len as usize - 1];
+            self.read_exact(&mut buf)?;
+
+            let terminator = self.read_u8()?;
+            if terminator != 0 {
+                Err(DeserializeError::InvalidStringTerminator(
+                    terminator as u16,
+                    self.stream_position()?,
+                ))?
+            }
+
+            let string = String::from_utf8(buf)
+                .map_err(|e| DeserializeError::FromUtf8Error(e, start_position))?;
+
+            Ok(Some(string))
+        }
+    }
+
     #[inline]
     fn read_guid(&mut self) -> Result<Guid, Error> {
         let mut guid = Guid::default();
         self.read_exact(&mut guid.0)?;
         Ok(guid)
+    }
+
+    #[inline]
+    fn read_bool(&mut self) -> Result<bool, Error> {
+        match self.read_u8()? {
+            0 => Ok(false),
+            1 => Ok(true),
+            value => Err(DeserializeError::InvalidBoolean(
+                value as u32,
+                self.stream_position()?,
+            ))?,
+        }
     }
 
     #[inline]
@@ -81,12 +146,45 @@ impl<R: Read + Seek> ReadExt for R {
 impl<W: Write> WriteExt for W {
     #[inline]
     fn write_string<T: AsRef<str>>(&mut self, v: T) -> Result<usize, Error> {
-        Ok(self.write_fstring(Some(v.as_ref()))?)
+        let v = v.as_ref();
+        if v.is_ascii() {
+            // ASCII strings do not require encoding
+            let len = v.len() + 1;
+            self.write_i32::<LittleEndian>(len as i32)?;
+            let _ = self.write(v.as_bytes())?;
+            let _ = self.write(&[0u8; 1])?;
+            Ok(len * 2 + 4)
+        } else {
+            // Perform UTF-16 encoding when non-ASCII characters are detected
+            let words: Vec<u16> = v.encode_utf16().collect();
+            let len = words.len() + 1;
+            self.write_i32::<LittleEndian>(-(len as i32))?;
+            for word in words {
+                self.write_u16::<LittleEndian>(word)?;
+            }
+            self.write_u16::<LittleEndian>(0u16)?;
+            Ok(len * 2 + 4)
+        }
+    }
+
+    fn write_fstring(&mut self, v: Option<&str>) -> Result<usize, Error> {
+        match v {
+            Some(str) => self.write_string(str),
+            None => {
+                self.write_i32::<LittleEndian>(0)?;
+                Ok(4)
+            }
+        }
     }
 
     #[inline]
     fn write_guid(&mut self, v: &Guid) -> Result<(), Error> {
         Ok(self.write_all(&v.0)?)
+    }
+
+    #[inline]
+    fn write_bool(&mut self, v: bool) -> Result<(), Error> {
+        Ok(self.write_u8(if v { 1 } else { 0 })?)
     }
 
     #[inline]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,9 @@
-use std::io;
+use std::{
+    io,
+    string::{FromUtf16Error, FromUtf8Error},
+};
 
 use thiserror::Error;
-use unreal_helpers::error::FStringError;
 
 /// Gets thrown when there is a deserialization error
 #[derive(Error, Debug)]
@@ -14,7 +16,10 @@ pub enum DeserializeError {
     InvalidValueSize(u64, u64, u64),
     /// If a string has invalid size
     #[error("Invalid string size {0} at position {1:#x}")]
-    InvalidString(u32, u64),
+    InvalidString(i32, u64),
+    /// Invalid string terminator
+    #[error("Invalid string terminator {0} at position {1:#x}")]
+    InvalidStringTerminator(u16, u64),
     /// If a boolean has invalid value
     #[error("Invalid boolean value {0} at position {1:#x}")]
     InvalidBoolean(u32, u64),
@@ -36,6 +41,12 @@ pub enum DeserializeError {
     /// Invalid terminator
     #[error("Unexpected terminator value {0} at position {1:#x}")]
     InvalidTerminator(u8, u64),
+    /// If a string has invalid UTF-16 formatting
+    #[error("Invalid UTF-16 string at position {1:#x}")]
+    FromUtf16Error(#[source] FromUtf16Error, u64),
+    /// If a string has invalid UTF-8 formatting
+    #[error("Invalid UTF-8 string at position {1:#x}")]
+    FromUtf8Error(#[source] FromUtf8Error, u64),
 }
 
 impl DeserializeError {
@@ -112,9 +123,6 @@ pub enum Error {
     /// A `SerializeError` occurred
     #[error(transparent)]
     Serialize(#[from] SerializeError),
-    /// An `FStringError` occured
-    #[error(transparent)]
-    FString(#[from] FStringError),
     /// An `std::io::Error` occured
     #[error(transparent)]
     Io(#[from] io::Error),

--- a/src/properties/enum_property.rs
+++ b/src/properties/enum_property.rs
@@ -1,7 +1,6 @@
 use std::io::{Cursor, Read, Seek, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use unreal_helpers::UnrealWriteExt;
 
 use crate::{
     cursor_ext::{ReadExt, WriteExt},

--- a/src/properties/int_property.rs
+++ b/src/properties/int_property.rs
@@ -5,7 +5,6 @@ use std::{
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use ordered_float::OrderedFloat;
-use unreal_helpers::{UnrealReadExt, UnrealWriteExt};
 
 use super::{
     impl_write,

--- a/src/properties/name_property.rs
+++ b/src/properties/name_property.rs
@@ -1,9 +1,8 @@
 use std::io::{Cursor, Read, Seek, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use unreal_helpers::{UnrealReadExt, UnrealWriteExt};
 
-use crate::{cursor_ext::WriteExt, error::Error};
+use crate::{cursor_ext::ReadExt, cursor_ext::WriteExt, error::Error};
 
 use super::{impl_read, impl_read_header, impl_write, PropertyOptions, PropertyTrait};
 

--- a/src/properties/str_property.rs
+++ b/src/properties/str_property.rs
@@ -1,9 +1,11 @@
 use std::io::{Cursor, Read, Seek, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use unreal_helpers::{UnrealReadExt, UnrealWriteExt};
 
-use crate::{cursor_ext::WriteExt, error::Error};
+use crate::{
+    cursor_ext::{ReadExt, WriteExt},
+    error::Error,
+};
 
 use super::{impl_read, impl_read_header, impl_write, PropertyOptions, PropertyTrait};
 

--- a/src/properties/text_property.rs
+++ b/src/properties/text_property.rs
@@ -8,7 +8,6 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use indexmap::IndexMap;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use ordered_float::OrderedFloat;
-use unreal_helpers::{UnrealReadExt, UnrealWriteExt};
 
 use crate::custom_version::FEditorObjectVersion;
 use crate::properties::int_property::UInt64Property;

--- a/tests/gvas_tests/name_arrayindex.rs
+++ b/tests/gvas_tests/name_arrayindex.rs
@@ -1,8 +1,8 @@
+use gvas::cursor_ext::ReadExt;
 use gvas::properties::{name_property::NameProperty, PropertyOptions, PropertyTrait};
 use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::io::Cursor;
-use unreal_helpers::UnrealReadExt;
 
 #[test]
 fn name_property_with_array_index() {

--- a/tests/gvas_tests/test_cursor.rs
+++ b/tests/gvas_tests/test_cursor.rs
@@ -27,6 +27,32 @@ fn test_write_string() -> Result<(), Error> {
 }
 
 #[test]
+fn test_write_fstring() -> Result<(), Error> {
+    // ASCII
+    let mut cursor = Cursor::new(Vec::new());
+    cursor.write_fstring(Some("test"))?;
+    assert_eq!(
+        cursor.get_ref(),
+        &[5u8, 0u8, 0u8, 0u8, b't', b'e', b's', b't', 0u8],
+    );
+
+    // Non-ASCII
+    let mut cursor = Cursor::new(Vec::new());
+    cursor.write_fstring(Some("\u{A7}"))?;
+    assert_eq!(
+        cursor.get_ref(),
+        &[0xfeu8, 0xffu8, 0xffu8, 0xffu8, 0xa7u8, 0u8, 0u8, 0u8],
+    );
+
+    // Null
+    let mut cursor = Cursor::new(Vec::new());
+    cursor.write_fstring(None)?;
+    assert_eq!(cursor.get_ref(), &[0u8; 4],);
+
+    Ok(())
+}
+
+#[test]
 fn test_read_string() -> Result<(), Error> {
     // ASCII
     let mut cursor = Cursor::new(vec![5u8, 0u8, 0u8, 0u8, b't', b'e', b's', b't', 0u8]);
@@ -46,12 +72,42 @@ fn test_read_string() -> Result<(), Error> {
     // Missing null terminator
     let mut cursor = Cursor::new(vec![1u8, 0u8, 0u8, 0u8, b't']);
     let string = cursor.read_string().expect_err("Expected err").to_string();
-    assert_eq!(string, "Invalid string terminator 116 at position 5");
+    assert_eq!(string, "Invalid string terminator 116 at position 0x5");
 
     // Missing null terminator, UTF-16
     let mut cursor = Cursor::new(vec![0xffu8, 0xffu8, 0xffu8, 0xffu8, b't', b'e']);
     let string = cursor.read_string().expect_err("Expected err").to_string();
-    assert_eq!(string, "Invalid string terminator 25972 at position 6");
+    assert_eq!(string, "Invalid string terminator 25972 at position 0x6");
+
+    Ok(())
+}
+
+#[test]
+fn test_read_fstring() -> Result<(), Error> {
+    // ASCII
+    let mut cursor = Cursor::new(vec![5u8, 0u8, 0u8, 0u8, b't', b'e', b's', b't', 0u8]);
+    let string = cursor.read_fstring()?.expect("Expected Some");
+    assert_eq!(string, "test");
+
+    // Non-ASCII
+    let mut cursor = Cursor::new(vec![0xfeu8, 0xffu8, 0xffu8, 0xffu8, 0xa7u8, 0u8, 0u8, 0u8]);
+    let string = cursor.read_fstring()?.expect("Expected Some");
+    assert_eq!(string, "\u{A7}");
+
+    // Null
+    let mut cursor = Cursor::new(vec![0u8; 4]);
+    let string = cursor.read_fstring()?;
+    assert_eq!(string, None);
+
+    // Missing null terminator
+    let mut cursor = Cursor::new(vec![1u8, 0u8, 0u8, 0u8, b't']);
+    let string = cursor.read_fstring().expect_err("Expected err").to_string();
+    assert_eq!(string, "Invalid string terminator 116 at position 0x5");
+
+    // Missing null terminator, UTF-16
+    let mut cursor = Cursor::new(vec![0xffu8, 0xffu8, 0xffu8, 0xffu8, b't', b'e']);
+    let string = cursor.read_fstring().expect_err("Expected err").to_string();
+    assert_eq!(string, "Invalid string terminator 25972 at position 0x6");
 
     Ok(())
 }


### PR DESCRIPTION
Closes #99 by resolving a UTF-16 conversion bug, and add CI checks for two big endian hosts (`powerpc`, `s390x`) via the [cross](https://github.com/cross-rs/cross) crate.