### PR TITLE
Move clippy rules to lib.rs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,4 @@ jobs:
         run: cargo fmt --check --all
 
       - name: Clippy
-        run: cargo clippy --all-features -- -D warnings -D clippy::expect_used -D clippy::panic -D clippy::unwrap_used
-
-      - name: Clippy (tests)
         run: cargo clippy --all-features --all-targets -- -D warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 #![warn(missing_docs)]
 
 //! Gvas

--- a/src/properties/name_property.rs
+++ b/src/properties/name_property.rs
@@ -20,7 +20,6 @@ pub struct NameProperty {
     pub value: Option<String>,
 }
 
-#[allow(clippy::trivially_copy_pass_by_ref)]
 #[cfg(feature = "serde")]
 fn is_zero(num: &u32) -> bool {
     *num == 0


### PR DESCRIPTION
Allow developers to view clippy violations as warnings during development.