### PR TITLE
Resolve clippy::legacy_numeric_constants error

### DIFF
--- a/src/properties/text_property.rs
+++ b/src/properties/text_property.rs
@@ -1,5 +1,4 @@
 use std::hash::{Hash, Hasher};
-use std::usize;
 use std::{
     fmt::Debug,
     io::{Cursor, Read, Seek, Write},


### PR DESCRIPTION
The rust beta build is failing due to a new clippy rule:

```
error: importing legacy numeric constants
 --> src/properties/text_property.rs:2:5
  |
2 | use std::usize;
  |     ^^^^^^^^^^
  |
  = help: remove this import
  = note: then `usize::<CONST>` will resolve to the respective associated constant
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
  = note: `-D clippy::legacy-numeric-constants` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(clippy::legacy_numeric_constants)]`
```