### PR TITLE
Add a makefile to simplify local testing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# https://editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: ready fmt format lint test clean
+ready: format lint test
+fmt: format
+format: # Formats all bin and lib files of the current crate using rustfmt.
+	cargo fmt --all
+lint: # Run rustfmt and clippy lints.
+	cargo fmt --check --all
+	cargo clippy --all-targets --all-features -- -D warnings
+test: # Run all tests.
+	cargo build --all-targets --verbose --workspace
+	cargo test --all-targets --verbose --workspace
+	cargo build --all-targets --all-features --verbose --workspace
+	cargo test --all-targets --all-features --verbose --workspace
+clean:
+	cargo clean


### PR DESCRIPTION
This change makes it easier to run tests and lints locally the same way that the CI checks run them by running `make` commands.