### PR TITLE
Create FSaveGameFileVersion::Type and EUnrealEngineObjectUE5Version enums

### DIFF
--- a/src/object_version.rs
+++ b/src/object_version.rs
@@ -1,0 +1,47 @@
+use num_enum::IntoPrimitive;
+
+/// UE5 object versions.
+#[derive(IntoPrimitive)]
+#[repr(u32)]
+pub enum EUnrealEngineObjectUE5Version {
+    /// The original UE5 version, at the time this was added the UE4 version was 522, so UE5 will start from 1000 to show a clear difference
+    InitialVersion = 1000,
+
+    /// Support stripping names that are not referenced from export data
+    NamesReferencedFromExportData,
+
+    /// Added a payload table of contents to the package summary
+    PayloadToc,
+
+    /// Added data to identify references from and to optional package
+    OptionalResources,
+
+    /// Large world coordinates converts a number of core types to double components by default.
+    LargeWorldCoordinates,
+
+    /// Remove package GUID from FObjectExport
+    RemoveObjectExportPackageGuid,
+
+    /// Add IsInherited to the FObjectExport entry
+    TrackObjectExportIsInherited,
+
+    /// Replace FName asset path in FSoftObjectPath with (package name, asset name) pair FTopLevelAssetPath
+    FsoftobjectpathRemoveAssetPathFnames,
+
+    /// Add a soft object path list to the package summary for fast remap
+    AddSoftobjectpathList,
+
+    /// Added bulk/data resource table
+    DataResources,
+
+    /// Added script property serialization offset to export table entries for saved, versioned packages
+    ScriptSerializationOffset,
+
+    /// Adding property tag extension,
+    /// Support for overridable serialization on UObject,
+    /// Support for overridable logic in containers
+    PropertyTagExtensionAndOverridableSerialization,
+
+    /// Added property tag complete type name and serialization type
+    PropertyTagCompleteTypeName,
+}

--- a/src/savegame_version.rs
+++ b/src/savegame_version.rs
@@ -1,0 +1,13 @@
+use num_enum::IntoPrimitive;
+
+/// Save Game File Version from FSaveGameFileVersion::Type
+#[derive(IntoPrimitive)]
+#[repr(u32)]
+pub enum SaveGameVersion {
+    /// Initial version.
+    InitialVersion = 1,
+    /// serializing custom versions into the savegame data to handle that type of versioning
+    AddedCustomVersions = 2,
+    /// added a new UE5 version number to FPackageFileSummary
+    PackageFileSummaryVersionChange = 3,
+}

--- a/tests/common/vector2d.rs
+++ b/tests/common/vector2d.rs
@@ -23,7 +23,7 @@ pub(crate) fn expected() -> GvasFile {
         deserialized_game_version: DeserializedGameVersion::Default,
         header: GvasHeader::Version3 {
             package_file_version: 522,
-            unknown: 1009,
+            package_file_version_ue5: 1009,
             engine_version: FEngineVersion {
                 major: 5,
                 minor: 3,
@@ -809,7 +809,7 @@ pub const VECTOR2D_JSON: &str = r#"{
   "header": {
     "type": "Version3",
     "package_file_version": 522,
-    "unknown": 1009,
+    "package_file_version_ue5": 1009,
     "engine_version": {
       "major": 5,
       "minor": 3,


### PR DESCRIPTION
Create enums for `EUnrealEngineObjectUE5Version` and `FSaveGameFileVersion::Type`, and use them in place of hard-coded values.

It may also be possible to create an enum from `EUnrealEngineObjectUE4Version` if this approach is desirable.

References:
- [Engine/Source/Runtime/Core/Public/UObject/ObjectVersion.h#L39-L90](https://github.com/EpicGames/UnrealEngine/blob/40eea367040d50aadd9f030ed5909fc890c159c2/Engine/Source/Runtime/Core/Public/UObject/ObjectVersion.h#L39-L90)
- [Engine/Source/Runtime/Engine/Private/GameplayStatics.cpp#L88-L99](https://github.com/EpicGames/UnrealEngine/blob/40eea367040d50aadd9f030ed5909fc890c159c2/Engine/Source/Runtime/Engine/Private/GameplayStatics.cpp#L88-L99)