### PR TITLE
Simplify ArgumentFormat serialized form

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/localcc/gvas"
 repository = "https://github.com/localcc/gvas"
 readme = "README.md"
 license = "MIT"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 
 [dependencies]

--- a/tests/serde_tests/serde_json_template.rs
+++ b/tests/serde_tests/serde_json_template.rs
@@ -21,8 +21,8 @@ use gvas::{
             DateTime, IntPoint, LinearColor, QuatD, QuatF, RotatorD, RotatorF, VectorD, VectorF,
         },
         text_property::{
-            DateTimeStyle, FText, FTextHistory, FormatArgumentData, FormatArgumentValue,
-            NumberFormattingOptions, RoundingMode, TextProperty, TransformType,
+            DateTimeStyle, FText, FTextHistory, FormatArgumentValue, NumberFormattingOptions,
+            RoundingMode, TextProperty, TransformType,
         },
         unknown_property::UnknownProperty,
         Property,
@@ -1772,10 +1772,10 @@ fn text_argumentformat() {
                         culture_invariant_string: None,
                     },
                 }),
-                arguments: vec![FormatArgumentData {
-                    name: String::from("key"),
-                    value: FormatArgumentValue::UInt(2),
-                }],
+                arguments: HashableIndexMap(IndexMap::from([(
+                    String::from("key"),
+                    FormatArgumentValue::UInt(2),
+                )])),
             },
         })),
         r#"{
@@ -1785,14 +1785,11 @@ fn text_argumentformat() {
     "flags": 1,
     "history": "None"
   },
-  "arguments": [
-    {
-      "name": "key",
-      "value": {
-        "UInt": 2
-      }
+  "arguments": {
+    "key": {
+      "UInt": 2
     }
-  ]
+  }
 }"#,
     );
 }


### PR DESCRIPTION
Apply the same optimization to `ArgumentFormat` that was used for `NameFormat`.