### PR TITLE
Fix LargeWorldCoordinates detection

### DIFF
--- a/src/custom_version.rs
+++ b/src/custom_version.rs
@@ -267,3 +267,170 @@ impl_custom_version_trait!(
     VER_UE4_12: GatheredTextPackageCacheFixesV1,
     VER_UE4_OLDEST_LOADABLE_PACKAGE: BeforeCustomVersionWasAdded
 );
+
+/// Custom serialization version for changes made in //UE5/Release-* stream
+#[derive(IntoPrimitive)]
+#[repr(u32)]
+pub enum FUE5ReleaseStreamObjectVersion {
+    /// Before any version changes were made
+    BeforeCustomVersionWasAdded = 0,
+
+    /// Added Lumen reflections to new reflection enum, changed defaults
+    ReflectionMethodEnum,
+
+    /// Serialize HLOD info in WorldPartitionActorDesc
+    WorldPartitionActorDescSerializeHLODInfo,
+
+    /// Removing Tessellation from materials and meshes.
+    RemovingTessellation,
+
+    /// LevelInstance serialize runtime behavior
+    LevelInstanceSerializeRuntimeBehavior,
+
+    /// Refactoring Pose Asset runtime data structures
+    PoseAssetRuntimeRefactor,
+
+    /// Serialize the folder path of actor descs
+    WorldPartitionActorDescSerializeActorFolderPath,
+
+    /// Change hair strands vertex format
+    HairStrandsVertexFormatChange,
+
+    /// Added max linear and angular speed to Chaos bodies
+    AddChaosMaxLinearAngularSpeed,
+
+    /// PackedLevelInstance version
+    PackedLevelInstanceVersion,
+
+    /// PackedLevelInstance bounds fix
+    PackedLevelInstanceBoundsFix,
+
+    /// Custom property anim graph nodes (linked anim graphs, control rig etc.) now use optional pin manager
+    CustomPropertyAnimGraphNodesUseOptionalPinManager,
+
+    /// Add native double and int64 support to FFormatArgumentData
+    TextFormatArgumentData64bitSupport,
+
+    /// Material layer stacks are no longer considered 'static parameters'
+    MaterialLayerStacksAreNotParameters,
+
+    /// CachedExpressionData is moved from UMaterial to UMaterialInterface
+    MaterialInterfaceSavedCachedData,
+
+    /// Add support for multiple cloth deformer LODs to be able to raytrace cloth with a different LOD than the one it is rendered with
+    AddClothMappingLODBias,
+
+    /// Add support for different external actor packaging schemes
+    AddLevelActorPackagingScheme,
+
+    /// Add support for linking to the attached parent actor in WorldPartitionActorDesc
+    WorldPartitionActorDescSerializeAttachParent,
+
+    /// Converted AActor GridPlacement to bIsSpatiallyLoaded flag
+    ConvertedActorGridPlacementToSpatiallyLoadedFlag,
+
+    /// Fixup for bad default value for GridPlacement_DEPRECATED
+    ActorGridPlacementDeprecateDefaultValueFixup,
+
+    /// PackedLevelActor started using FWorldPartitionActorDesc (not currently checked against but added as a security)
+    PackedLevelActorUseWorldPartitionActorDesc,
+
+    /// Add support for actor folder objects
+    AddLevelActorFolders,
+
+    /// Remove FSkeletalMeshLODModel bulk datas
+    RemoveSkeletalMeshLODModelBulkDatas,
+
+    /// Exclude brightness from the EncodedHDRCubemap,
+    ExcludeBrightnessFromEncodedHDRCubemap,
+
+    /// Unified volumetric cloud component quality sample count slider between main and reflection views for consistency
+    VolumetricCloudSampleCountUnification,
+
+    /// Pose asset GUID generated from source AnimationSequence
+    PoseAssetRawDataGUID,
+
+    /// Convolution bloom now take into account FPostProcessSettings::BloomIntensity for scatter dispersion.
+    ConvolutionBloomIntensity,
+
+    /// Serialize FHLODSubActors instead of FGuids in WorldPartition HLODActorDesc
+    WorldPartitionHLODActorDescSerializeHLODSubActors,
+
+    /// Large Worlds - serialize double types as doubles
+    LargeWorldCoordinates,
+
+    /// Deserialize old BP float&double types as real numbers for pins
+    BlueprintPinsUseRealNumbers,
+
+    /// Changed shadow defaults for directional light components, version needed to not affect old things
+    UpdatedDirectionalLightShadowDefaults,
+
+    /// Refresh geometry collections that had not already generated convex bodies.
+    GeometryCollectionConvexDefaults,
+
+    /// Add faster damping calculations to the cloth simulation and rename previous Damping parameter to LocalDamping.
+    ChaosClothFasterDamping,
+
+    /// Serialize LandscapeActorGuid in FLandscapeActorDesc sub class.
+    WorldPartitionLandscapeActorDescSerializeLandscapeActorGuid,
+
+    /// add inertia tensor and rotation of mass to convex
+    AddedInertiaTensorAndRotationOfMassAddedToConvex,
+
+    /// Storing inertia tensor as vec3 instead of matrix.
+    ChaosInertiaConvertedToVec3,
+
+    /// For Blueprint real numbers, ensure that legacy float data is serialized as single-precision
+    SerializeFloatPinDefaultValuesAsSinglePrecision,
+
+    /// Upgrade the BlendMasks array in existing LayeredBoneBlend nodes
+    AnimLayeredBoneBlendMasks,
+
+    /// Uses RG11B10 format to store the encoded reflection capture data on mobile
+    StoreReflectionCaptureEncodedHDRDataInRG11B10Format,
+
+    /// Add WithSerializer type trait and implementation for FRawAnimSequenceTrack
+    RawAnimSequenceTrackSerializer,
+
+    /// Removed font from FEditableTextBoxStyle, and added FTextBlockStyle instead.
+    RemoveDuplicatedStyleInfo,
+
+    /// Added member reference to linked anim graphs
+    LinkedAnimGraphMemberReference,
+
+    /// Changed default tangent behavior for new dynamic mesh components
+    DynamicMeshComponentsDefaultUseExternalTangents,
+
+    /// Added resize methods to media capture
+    MediaCaptureNewResizeMethods,
+
+    /// Function data stores a map from work to debug operands
+    RigVMSaveDebugMapInGraphFunctionData,
+
+    /// Changed default Local Exposure Contrast Scale from 1.0 to 0.8
+    LocalExposureDefaultChangeFrom1,
+
+    /// Serialize bActorIsListedInSceneOutliner in WorldPartitionActorDesc
+    WorldPartitionActorDescSerializeActorIsListedInSceneOutliner,
+
+    /// Disabled opencolorio display configuration by default
+    OpenColorIODisabledDisplayConfigurationDefault,
+
+    /// Serialize ExternalDataLayerAsset in WorldPartitionActorDesc
+    WorldPartitionExternalDataLayers,
+
+    /// Fix Chaos Cloth fictitious angular scale bug that requires existing parameter rescaling.
+    ChaosClothFictitiousAngularVelocitySubframeFix,
+
+    /// Store physics thread particles data in single precision
+    SinglePrecisonParticleDataPT,
+
+    /// Orthographic Near and Far Plane Auto-resolve enabled by default
+    OrthographicAutoNearFarPlane,
+}
+
+impl_custom_version_trait!(
+    FUE5ReleaseStreamObjectVersion,
+    "FUE5ReleaseStreamObjectVersion",
+    Guid::from_u32([0xD89B5E42, 0x24BD4D46, 0x8412ACA8, 0xDF641779]),
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,19 +342,6 @@ pub struct GvasFile {
     pub properties: HashableIndexMap<String, Property>,
 }
 
-trait GvasHeaderTrait {
-    fn use_large_world_coordinates(&self) -> bool;
-}
-
-impl GvasHeaderTrait for GvasHeader {
-    fn use_large_world_coordinates(&self) -> bool {
-        match self {
-            GvasHeader::Version2 { .. } => false,
-            GvasHeader::Version3 { .. } => true,
-        }
-    }
-}
-
 impl GvasFile {
     /// Read GvasFile from a binary file
     ///
@@ -476,7 +463,6 @@ impl GvasFile {
         let mut options = PropertyOptions {
             hints,
             properties_stack: &mut vec![],
-            large_world_coordinates: header.use_large_world_coordinates(),
             custom_versions: header.get_custom_versions(),
         };
 
@@ -536,7 +522,6 @@ impl GvasFile {
         let mut options = PropertyOptions {
             hints: &HashMap::new(),
             properties_stack: &mut vec![],
-            large_world_coordinates: self.header.use_large_world_coordinates(),
             custom_versions: self.header.get_custom_versions(),
         };
 

--- a/src/properties/mod.rs
+++ b/src/properties/mod.rs
@@ -441,8 +441,6 @@ pub struct PropertyOptions<'a> {
     pub properties_stack: &'a mut Vec<String>,
     /// Custom versions
     pub custom_versions: &'a HashableIndexMap<Guid, u32>,
-    /// Enables large world coordinates.
-    pub large_world_coordinates: bool,
 }
 
 impl PropertyOptions<'_> {

--- a/src/properties/struct_property.rs
+++ b/src/properties/struct_property.rs
@@ -9,11 +9,11 @@ use indexmap::IndexMap;
 
 use crate::{
     cursor_ext::{ReadExt, WriteExt},
+    custom_version::FUE5ReleaseStreamObjectVersion,
     error::{DeserializeError, Error, SerializeError},
     properties::{name_property::NameProperty, struct_types::LinearColor},
     scoped_stack_entry::ScopedStackEntry,
-    types::map::HashableIndexMap,
-    types::Guid,
+    types::{map::HashableIndexMap, Guid},
 };
 
 use super::{
@@ -238,7 +238,8 @@ impl PropertyTrait for StructPropertyValue {
         match self {
             StructPropertyValue::Vector2F(vector) => {
                 validate!(
-                    !options.large_world_coordinates,
+                    !options
+                        .supports_version(FUE5ReleaseStreamObjectVersion::LargeWorldCoordinates),
                     "Vector2F not supported when LWC is enabled, use Vector2D",
                 );
                 cursor.write_f32::<LittleEndian>(vector.x.0)?;
@@ -247,7 +248,7 @@ impl PropertyTrait for StructPropertyValue {
             }
             StructPropertyValue::Vector2D(vector) => {
                 validate!(
-                    options.large_world_coordinates,
+                    options.supports_version(FUE5ReleaseStreamObjectVersion::LargeWorldCoordinates),
                     "Vector2D not supported when LWC is disabled, use Vector2F",
                 );
                 cursor.write_f64::<LittleEndian>(vector.x.0)?;
@@ -256,7 +257,8 @@ impl PropertyTrait for StructPropertyValue {
             }
             StructPropertyValue::VectorF(vector) => {
                 validate!(
-                    !options.large_world_coordinates,
+                    !options
+                        .supports_version(FUE5ReleaseStreamObjectVersion::LargeWorldCoordinates),
                     "VectorF not supported when LWC is enabled, use VectorD",
                 );
                 cursor.write_f32::<LittleEndian>(vector.x.0)?;
@@ -266,7 +268,7 @@ impl PropertyTrait for StructPropertyValue {
             }
             StructPropertyValue::VectorD(vector) => {
                 validate!(
-                    options.large_world_coordinates,
+                    options.supports_version(FUE5ReleaseStreamObjectVersion::LargeWorldCoordinates),
                     "VectorD not supported when LWC is disabled, use VectorF",
                 );
                 cursor.write_f64::<LittleEndian>(vector.x.0)?;
@@ -276,7 +278,8 @@ impl PropertyTrait for StructPropertyValue {
             }
             StructPropertyValue::RotatorF(rotator) => {
                 validate!(
-                    !options.large_world_coordinates,
+                    !options
+                        .supports_version(FUE5ReleaseStreamObjectVersion::LargeWorldCoordinates),
                     "RotatorF not supported when LWC is enabled, use RotatorD",
                 );
                 cursor.write_f32::<LittleEndian>(rotator.pitch.0)?;
@@ -286,7 +289,7 @@ impl PropertyTrait for StructPropertyValue {
             }
             StructPropertyValue::RotatorD(rotator) => {
                 validate!(
-                    options.large_world_coordinates,
+                    options.supports_version(FUE5ReleaseStreamObjectVersion::LargeWorldCoordinates),
                     "RotatorD not supported when LWC is disabled, use RotatorF",
                 );
                 cursor.write_f64::<LittleEndian>(rotator.pitch.0)?;
@@ -296,7 +299,8 @@ impl PropertyTrait for StructPropertyValue {
             }
             StructPropertyValue::QuatF(quat) => {
                 validate!(
-                    !options.large_world_coordinates,
+                    !options
+                        .supports_version(FUE5ReleaseStreamObjectVersion::LargeWorldCoordinates),
                     "QuatF not supported when LWC is enabled, use QuatD",
                 );
                 cursor.write_f32::<LittleEndian>(quat.x.0)?;
@@ -307,7 +311,7 @@ impl PropertyTrait for StructPropertyValue {
             }
             StructPropertyValue::QuatD(quat) => {
                 validate!(
-                    options.large_world_coordinates,
+                    options.supports_version(FUE5ReleaseStreamObjectVersion::LargeWorldCoordinates),
                     "QuatD not supported when LWC is disabled, use QuatF",
                 );
                 cursor.write_f64::<LittleEndian>(quat.x.0)?;
@@ -412,7 +416,7 @@ impl StructPropertyValue {
         cursor: &mut R,
         options: &mut PropertyOptions,
     ) -> Result<Self, Error> {
-        match options.large_world_coordinates {
+        match options.supports_version(FUE5ReleaseStreamObjectVersion::LargeWorldCoordinates) {
             true => Ok(Self::QuatD(QuatD::new(
                 cursor.read_f64::<LittleEndian>()?,
                 cursor.read_f64::<LittleEndian>()?,
@@ -432,7 +436,7 @@ impl StructPropertyValue {
         cursor: &mut R,
         options: &mut PropertyOptions,
     ) -> Result<Self, Error> {
-        match options.large_world_coordinates {
+        match options.supports_version(FUE5ReleaseStreamObjectVersion::LargeWorldCoordinates) {
             true => Ok(Self::RotatorD(RotatorD::new(
                 cursor.read_f64::<LittleEndian>()?,
                 cursor.read_f64::<LittleEndian>()?,
@@ -450,7 +454,7 @@ impl StructPropertyValue {
         cursor: &mut R,
         options: &mut PropertyOptions,
     ) -> Result<Self, Error> {
-        match options.large_world_coordinates {
+        match options.supports_version(FUE5ReleaseStreamObjectVersion::LargeWorldCoordinates) {
             true => Ok(Self::Vector2D(Vector2D::new(
                 cursor.read_f64::<LittleEndian>()?,
                 cursor.read_f64::<LittleEndian>()?,
@@ -466,7 +470,7 @@ impl StructPropertyValue {
         cursor: &mut R,
         options: &mut PropertyOptions,
     ) -> Result<Self, Error> {
-        match options.large_world_coordinates {
+        match options.supports_version(FUE5ReleaseStreamObjectVersion::LargeWorldCoordinates) {
             true => Ok(Self::VectorD(VectorD::new(
                 cursor.read_f64::<LittleEndian>()?,
                 cursor.read_f64::<LittleEndian>()?,

--- a/tests/gvas_tests/errors.rs
+++ b/tests/gvas_tests/errors.rs
@@ -70,7 +70,6 @@ fn test_invalid_array_index() {
     let mut options = PropertyOptions {
         hints: &HashMap::new(),
         properties_stack: &mut Vec::new(),
-        large_world_coordinates: false,
         custom_versions: &HashableIndexMap::new(),
     };
 
@@ -156,7 +155,6 @@ fn test_invalid_terminator() {
     let mut options = PropertyOptions {
         hints: &HashMap::new(),
         properties_stack: &mut Vec::new(),
-        large_world_coordinates: false,
         custom_versions: &HashableIndexMap::new(),
     };
 
@@ -265,7 +263,6 @@ fn test_invalid_length() {
     let mut options = PropertyOptions {
         hints: &HashMap::new(),
         properties_stack: &mut Vec::new(),
-        large_world_coordinates: false,
         custom_versions: &HashableIndexMap::new(),
     };
 

--- a/tests/gvas_tests/name_arrayindex.rs
+++ b/tests/gvas_tests/name_arrayindex.rs
@@ -32,7 +32,6 @@ fn name_property_with_array_index() {
     let mut options = PropertyOptions {
         hints: &HashMap::new(),
         properties_stack: &mut Vec::new(),
-        large_world_coordinates: false,
         custom_versions: &HashableIndexMap::new(),
     };
     let mut writer = Cursor::new(Vec::new());

--- a/tests/gvas_tests/test_property.rs
+++ b/tests/gvas_tests/test_property.rs
@@ -32,7 +32,6 @@ macro_rules! test_property {
             let mut options = PropertyOptions {
                 hints: &HashMap::new(),
                 properties_stack: &mut Vec::new(),
-                large_world_coordinates: false,
                 custom_versions: &HashableIndexMap::new(),
             };
 


### PR DESCRIPTION
This crate will incorrectly detect the value of LWC for some of the oldest UE5 versions. This change fixes the issue by changing the method of detection to the one which UE5 actually uses to detect LWC.